### PR TITLE
chore: remove unused FAQ anchors

### DIFF
--- a/docs/faq/overview.md
+++ b/docs/faq/overview.md
@@ -8,14 +8,12 @@ custom_edit_url: null
 
 # Frequently Asked Questions
 
-## Questions about Bitcoin Staking
+- [Questions about Bitcoin Staking](#questions-about-bitcoin-staking)
+  - [Will my bitcoins be bridged to other blockchains?](#will-my-bitcoins-be-bridged-to-other-blockchains)
+  - [As a bitcoin staker, do I have to run a validator by myself?](#as-a-bitcoin-staker-do-i-have-to-run-a-validator-by-myself)
+  - [When slashing happens, will all my staked bitcoins be burned?](#when-slashing-happens-will-all-my-staked-bitcoins-be-burned)
 
-- [Frequently Asked Questions](#frequently-asked-questions)
-  - [Questions about Bitcoin Staking](#questions-about-bitcoin-staking)
-    - [Will my bitcoins be bridged to other blockchains?](#will-my-bitcoins-be-bridged-to-other-blockchains)
-    - [As a bitcoin staker, do I have to run a validator by myself?](#as-a-bitcoin-staker-do-i-have-to-run-a-validator-by-myself)
-    - [When slashing happens, will all my staked bitcoins be burned?](#when-slashing-happens-will-all-my-staked-bitcoins-be-burned)
-  - [Questions about Bitcoin Timestamping](#questions-about-bitcoin-timestamping)
+## Questions about Bitcoin Staking
 
 ### Will my bitcoins be bridged to other blockchains?
 


### PR DESCRIPTION
<img width="899" alt="image" src="https://github.com/user-attachments/assets/e9f40262-429a-4bbd-9ef5-0f55da192e10">

there are some warning during build. it turns out to be the new version will detect if there is any dead links/anchors.
Hence removed the dead anchors in this PR