### PR TITLE
Update dapps.mdx

### DIFF
--- a/docs/developers/dapps/dapps.mdx
+++ b/docs/developers/dapps/dapps.mdx
@@ -6,19 +6,19 @@ sidebar_position: 1
 
 # Bitcoin Secured dApps
 
-dApps deployed on Babbylon Genesis automatically inherit unprecedented security guarantee 
+dApps deployed on Babylon Genesis automatically inherit unprecedented security guarantees 
 from staked BTCs. 
 
-Babbylon Genesis is built on Cosmos SDK and uses the CometBFT consensus engine. The 
-implementation of CosmWasm Virtual machine allows developers to gain sophisticated 
+Babylon Genesis is built on Cosmos SDK and uses the CometBFT consensus engine. The 
+implementation of the CosmWasm Virtual Machine allows developers to gain sophisticated 
 programming capabilities of the staked security or on-chain information. This is able 
 to sustain complex decentralized applications.
 
-Applications developed on Babbylon Genesis can gain access to an unique market position 
-as it intersects Bitcoin's significant liquidity pool and utilized Bitcoin's already 
+Applications developed on Babylon Genesis can gain access to a unique market position 
+as it intersects Bitcoin's significant liquidity pool and utilizes Bitcoin's already 
 established network effects. 
 
-Read more about how to deploy your smart contracts on Babbylon Genesis 
+Read more about how to deploy your smart contracts on Babylon Genesis 
 [here](/developers/dapps/smart_contract_deployment)
 
 


### PR DESCRIPTION
- Corrected "Babbylon" to "Babylon" throughout the document (appears multiple times)
- Changed "inherit unprecedented security guarantee" to "inherit unprecedented security guarantees" (plural form)
- Improved "The implementation of CosmWasm Virtual machine" to "The implementation of the CosmWasm Virtual Machine" (added article and proper capitalization)
- Corrected "gain access to an unique" to "gain access to a unique" (correct article usage before "unique")
- Changed "utilized Bitcoin's" to "utilizes Bitcoin's"