### PR TITLE
Update faqs.mdx

### DIFF
--- a/docs/operators/faqs.mdx
+++ b/docs/operators/faqs.mdx
@@ -5,14 +5,14 @@ sidebar_position: 9
 
 # Operator Frequently Asked Questions
 
-## Babbylon Genesis Validators
+## Babylon Genesis Validators
 
 ## Recommendations
 
-- Regularly monitor your node's status
-- Keep your node software and configurations up to date
-- Maintain secure and reliable deployment infrastructure
-- Participate in community channels for the latest updates and changes
+- Regularly monitor your node's status.
+- Keep your node software and configurations up to date.
+- Maintain secure and reliable deployment infrastructure.
+- Participate in community channels for the latest updates and changes.
 
 ### FAQs
 
@@ -22,20 +22,20 @@ You can download the genesis file from
 [Babylon Labs' networks repository](https://github.com/babylonlabs-io/networks/blob/main/bbn-test-5/network-artifacts/genesis.json).
 Ensure you're using the correct version of the Babylon binary specified in the documentation.
 
-#### Q: What are the hardware requirements for running Babylon nodes and finality providers?
+#### Q: What are the hardware requirements for running Babylon nodes and a Finality Provider?
 **A:**
 An instance with at least 8 GB of RAM should be sufficient to host both a
-Babylon node and a finality provider. However, for better reliability, it is recommended
+Babylon node and a Finality Provider. However, for better reliability, it is recommended
 to run them on separate instances.
 
-#### Q: How do I set up my Babylon validator?
+#### Q: How do I set up my Babylon Validator?
 **A:**
 Follow these steps:
 - Install the required Babylon binary.
 - Initialize your node with `babylond init`.
 - Sync from the correct genesis file or a snapshot.
 - Configure `config.toml` and add persistent peers.
-- Register your validator with `babylond tx staking create-validator`.
+- Register your Validator with `babylond tx staking create-validator`.
 Refer to the [official setup guide](https://github.com/babylonlabs-io/networks/blob/main/bbn-test-5/babylon-node/README.md)
 for details.
 
@@ -45,9 +45,9 @@ Open the following ports:
 - **RPC Port:** 26657
 - **gRPC Port:** 9090
 - **P2P Port:** 26656
-Ensure proper firewall rules if your validator and finality provider are on different instances.
+Ensure proper firewall rules if your Validator and Finality Provider are on different instances.
 
-#### Q: How can I check my validator’s status?
+#### Q: How can I check my Validator’s status?
 **A:**
 Use:
 ```bash
@@ -56,7 +56,7 @@ babylond q staking validator <your-valoper-address>
 Alternatively, check your status on an explorer such as [Mintscan](https://www.mintscan.io/babylon-testnet/validators)
 or [L2Scan](https://babylon-testnet.l2scan.co/).
 
-#### Q: How do I upgrade my Babylon validator node?
+#### Q: How do I upgrade my Babylon Validator node?
 **A:**
 Try the following:
 - Stop your node.
@@ -71,17 +71,17 @@ If your node fails to start after an upgrade:
 - Check logs for error messages.
 - Ensure you're using the correct genesis file or state snapshot.
 - Run `unsafe-reset-all` and resync the node.
-- If necessary, reinitialize the validator and restore from a backup.
+- If necessary, reinitialize the Validator and restore from a backup.
 
 
-#### Q: What should I do if my validator is jailed?
+#### Q: What should I do if my Validator is jailed?
 **A:**
 Try the following:
 - Check logs for issues related to missed votes or incorrect configurations.
 - Run `babylond tx slashing unjail` to attempt unjailing.
-- Ensure your validator is active and signing correctly before attempting unjailing.
+- Ensure your Validator is active and signing correctly before attempting unjailing.
 
-#### Q: How do I stake and delegate tokens to a validator?
+#### Q: How do I stake and delegate tokens to a Validator?
 **A:**
 Use the following command:
 ```bash
@@ -90,15 +90,15 @@ babylond tx staking delegate <validator-address> <amount>ubbn --from <your-walle
 Ensure your wallet has sufficient balance to cover transaction fees.
 
 
-#### Q: How do I withdraw validator rewards?
+#### Q: How do I withdraw Validator rewards?
 **A:**
 Use the following command:
 ```bash
 babylond tx distribution withdraw-rewards <your-valoper-address> --from <your-wallet>
 ```
-Add `--commission` if you want to withdraw validator commission as well.
+Add `--commission` if you want to withdraw Validator commission as well.
 
-#### Q: How do I redelegate my stake to another validator?
+#### Q: How do I redelegate my stake to another Validator?
 **A:**
 Use:
 ```bash
@@ -116,18 +116,18 @@ Try the following:
 #### Q: What precautions should I take when resetting my node?
 **A:**
 Read the following:
-- **CAUTION:** Avoid using `unsafe-reset-all` without proper preparation
-- This command may remove BLS keys stored in `priv_validator_key.json`
-- Always create a backup of `priv_validator_key.json` before any reset
-- Wait for future updates that will separate BLS keys for improved safety
+- **CAUTION:** Avoid using `unsafe-reset-all` without proper preparation.
+- This command may remove BLS keys stored in `priv_validator_key.json`.
+- Always create a backup of `priv_validator_key.json` before any reset.
+- Wait for future updates that will separate BLS keys for improved safety.
 
 #### Q: How can I safely reset my Babylon node?
 **A:**
 Try the following:
-- Create a full backup of all critical configuration files
-- Specifically, backup `priv_validator_key.json`
-- Consult the latest Babylon documentation for recommended reset procedures
-- Consider reaching out to Babylon support if you're unsure about the reset process
+- Create a full backup of all critical configuration files.
+- Specifically, backup `priv_validator_key.json`.
+- Consult the latest Babylon documentation for recommended reset procedures.
+- Consider reaching out to Babylon support if you're unsure about the reset process.
 
 
 ## Finality Providers
@@ -135,14 +135,14 @@ Try the following:
 ### Recommendations
 
 **Connection Suggestions**
-   - Do not use multiple nodes behind a load balancer
-   - Always connect to a single, trusted Babylon RPC node
-   - Enable transaction indexing on your RPC node
+   - Do not use multiple nodes behind a load balancer.
+   - Always connect to a single, trusted Babylon RPC node.
+   - Enable transaction indexing on your RPC node.
 
 **Voting Mechanism Suggestions**
    - The jailing mechanism is similar to Cosmos SDK's native approach, Babylon
-Chain is built with the Cosmos SDK and uses the [x/slashing module](https://docs.cosmos.network/main/build/modules/slashing).
-   - It is designed to protect network integrity and prevent malicious activities
+Genesis is built with the Cosmos SDK and uses the [x/slashing module](https://docs.cosmos.network/main/build/modules/slashing).
+   - It is designed to protect network integrity and prevent malicious activities.
 
 ### Q&A
 
@@ -161,35 +161,35 @@ Run:
 ```bash
 babylond q finality provider <your-provider-address>
 ```
-Your provider should have active status and be voting on finality.
+Your provider should have an active status and be voting on finality.
 
 #### Q: What are the key recommendations for running a Finality Provider daemon?
 **A:**
 
 Follow these critical guidelines:
-- Connect your finality provider daemon to a trusted Babylon RPC node
-- Ensure you're connected to a single Babylon node (avoid load balancers)
-- Verify that your RPC node has transaction indexing enabled
+- Connect your Finality Provider daemon to a trusted Babylon RPC node.
+- Ensure you're connected to a single Babylon node (avoid load balancers).
+- Verify that your RPC node has transaction indexing enabled.
 
 #### Q: How can I prevent duplicate finality votes?
 **A:**
 Try the following:
-- Use a single, dedicated Babylon RPC node with transaction indexing enabled
-- Monitor your daemon's connection and status regularly
-- Check logs for any duplicate vote warnings
+- Use a single, dedicated Babylon RPC node with transaction indexing enabled.
+- Monitor your daemon's connection and status regularly.
+- Check logs for any duplicate vote warnings.
 
 #### Q: What should I do if my Finality Provider is jailed?
 **A:**
 Follow these steps:
-- Immediately check the status using `fpd finality-provider-info [eots-pk-hex]`
-- Verify your daemon's status on the Babylon staking dashboard
-- Investigate and resolve the underlying issue causing the jailing
-- Follow the official Babylon unjailing guide to restore your provider's status
+- Immediately check the status using `fpd finality-provider-info [eots-pk-hex]`.
+- Verify your daemon's status on the Babylon staking dashboard.
+- Investigate and resolve the underlying issue causing the jailing.
+- Follow the official Babylon unjailing guide to restore your provider's status.
 
 #### Q: What are the key recommendations for running a Finality Provider daemon?
 **A:**
 Follow these critical guidelines:
-- Connect your finality provider daemon to a trusted Babylon RPC node.
+- Connect your Finality Provider daemon to a trusted Babylon RPC node.
 - Ensure you're connected to a single Babylon node (avoid load balancers).
 - Verify that your RPC node has transaction indexing enabled.
 
@@ -212,11 +212,9 @@ Run:
 This is probably due to a new parameter appeared in the config and you could create a
 new default config with `eotsd init`, just remember to update the values to your key name and directory path
 
-
-
 ## Contact and Support
 
-For further assistance, please reach out to the Babbylon Genesis Validator and Finality Provider slack support channels (invit-only).
+For further assistance, please reach out to the Babylon Genesis Validator and Finality Provider Slack support channels (invite-only).
 
 :::warning
 This guide is based on the observation of current Babylon network


### PR DESCRIPTION
- Corrected spelling of "Babbylon" to "Babylon" in the Contact and Support section.
- Changed "invit-only" to "invite-only" in the Contact and Support section.
- Added missing periods at the end of recommendation bullet points.
- Capitalized "Finality Providers" and "Validators"