### PR TITLE
Update vigilantes.mdx

### DIFF
--- a/docs/operators/vigilantes/vigilantes.mdx
+++ b/docs/operators/vigilantes/vigilantes.mdx
@@ -6,22 +6,22 @@ sidebar_position: 4
 
 # Vigilantes Operators
 
-The Babylon network is monitored by the Babylon Validators and Vigilantes. They are 
+The Babylon network is monitored by Babylon Validators and Vigilantes. They are 
 critical infrastructure participants in the Babylon network who play a crucial role 
-in maintaining synchronization between Bitcoin and the Babbylon Genesis. They form a 
-decentralized network that ensures reliability by active monitoring and reporting.
+in maintaining synchronization between Bitcoin and Babylon Genesis. They form a 
+decentralized network that ensures reliability through active monitoring and reporting.
 
-There is no centralized coordination of vigilantes. Operators can also be running chain validator 
-nodes or finality providers. 
+There is no centralized coordination of Vigilantes. Operators can also be running chain Validator 
+nodes or Finality Providers. 
 
 ## Core Responsibilities
 
-There are three main responsibilities of vigilantes:
+There are three main responsibilities of Vigilantes:
 
-1. Corss-chain relay - ensures data between Bitcoin and Babbylon Genesiss are accurate 
-and synchronized in timely mannger.
-2. Bitcoin Timestamping - help record and verify Bitcoin block headers on Babbylon Genesis
-3. Monitor integrity - maintain reliable and trustless setup of Babylon protocol
+1. Cross-chain relay - ensures data between Bitcoin and Babylon Genesis are accurate 
+and synchronized in timely manner.
+2. Bitcoin Timestamping - helps record and verify Bitcoin block headers on Babylon Genesis.
+3. Monitor integrity - maintains reliable and trustless setup of the Babylon protocol.
 
 ## Prerequisites
 
@@ -36,7 +36,7 @@ to the network's robustness and may be positioned advantageously for future rewa
 
 ## Operational Considerations
 
-To reliably run a vigilante program, the following considerations are important:
+To reliably run a Vigilante program, the following considerations are important:
 - Consistent uptime
 - Regular software updates
 - Secure key management


### PR DESCRIPTION
- Corrected spelling of "Babbylon" to "Babylon"
- "Babbylon Genesiss" corrected to "Babylon Genesis"
- "Corss-chain" corrected to "Cross-chain"
- "mannger" corrected to "manner"
- Capitalization of "Vigilantes" throughout the document
- Changed "by active monitoring" to "through active monitoring" for improved readability.