### PR TITLE
Update babylon_validators.mdx

### DIFF
--- a/docs/operators/babylon_validators/babylon_validators.mdx
+++ b/docs/operators/babylon_validators/babylon_validators.mdx
@@ -4,13 +4,13 @@ sidebar_label: Babbylon Genesis Validators
 sidebar_position: 1
 ---
 
-# Babbylon Genesis Validators
+# Babylon Genesis Validators
 
-Babbylon Genesis follows the Cosmos SDK and CometBFT consensus protocol. 
+Babylon Genesis follows the Cosmos SDK and CometBFT consensus protocol. 
 
-In Phase 2 Testnet, Babylon accepts chain validators to join the network. 
-The upper bound of the active of validators is 100. However there is no limit 
-on the total number of validators.
+In Phase 2 Testnet, Babylon accepts chain Validators to join the network. 
+The upper bound of active Validators is 100. However there is no limit 
+on the total number of Validators.
 
 ## Prerequisites
 
@@ -24,10 +24,10 @@ for validator nodes
 There are two was to get tBABY for Phase 2 Testnet:
 
 1. [Babylon Labs Discord Faucet](https://discord.com/channels/1266159481218457600/1266159481218457600)
-2. [L2Scan Faucet (0.01 tBABY each quest)](https://babylon-testnet.l2scan.co/faucet)
-3. Reqeust it from a Babylon Labs supporting staff or message us on [discord](https://discord.com/channels/1046686458070700112/1282600119346270281n). 
+2. [L2Scan Faucet (0.01 tBABY each request)](https://babylon-testnet.l2scan.co/faucet)
+3. Request it from a Babylon Labs supporting staff or message us on [discord](https://discord.com/channels/1046686458070700112/1282600119346270281n). 
 
 ## Get Started
 
-Follow the [installation guide](/operators/babylon_validators/installation_guide) to install start your 
-Babbylon Genesis Validator journey.
+Follow the [installation guide](/operators/babylon_validators/installation_guide) to install and start your 
+Babylon Genesis Validator journey.


### PR DESCRIPTION
- Corrected spelling of "Babbylon" to "Babylon" throughout the document
- "was" corrected to "ways" in Faucets section
- "Reqeust" corrected to "Request" in Faucets section
- Capitalized "Validators" thoughout
- Improved readability with addition of articles