### PR TITLE
docs: update finality provider documentation to v1.1.0-rc.1

### DIFF
--- a/docs/operators/finality_providers/finality_providers.mdx
+++ b/docs/operators/finality_providers/finality_providers.mdx
@@ -13,8 +13,5 @@ export const rawUrl="https://raw.githubusercontent.com/babylonlabs-io/finality-p
 <RemoteMD
   rawUrl={rawUrl}
   hideRelease={false}
-  defaultRelease="v1.1.0-rc.1"
-  releaseVersions={{
-    "v1.1.0-rc.1": "https://raw.githubusercontent.com/babylonlabs-io/finality-provider/refs/tags/v1.1.0-rc.1/README.md", 
-  }}
+  defaultRelease="v2.0.2"
 />

--- a/docs/operators/finality_providers/finality_providers.mdx
+++ b/docs/operators/finality_providers/finality_providers.mdx
@@ -13,7 +13,7 @@ export const rawUrl="https://raw.githubusercontent.com/babylonlabs-io/finality-p
 <RemoteMD
   rawUrl={rawUrl}
   hideRelease={false}
-  defaultRelease="v1.0.0"
+  defaultRelease="v1.1.0-rc.1"
   releaseVersions={{
     "v1.1.0-rc.1": "https://raw.githubusercontent.com/babylonlabs-io/finality-provider/refs/tags/v1.1.0-rc.1/README.md", 
   }}

--- a/docs/operators/finality_providers/fp_core_specs.mdx
+++ b/docs/operators/finality_providers/fp_core_specs.mdx
@@ -13,8 +13,5 @@ export const rawUrl="https://raw.githubusercontent.com/babylonlabs-io/finality-p
 <RemoteMD
   rawUrl={rawUrl}
   hideRelease={false}
-  defaultRelease="v1.1.0-rc.1"
-  releaseVersions={{
-    "v1.1.0-rc.1": "https://raw.githubusercontent.com/babylonlabs-io/finality-provider/refs/tags/v1.1.0-rc.1/docs/fp-core.md", 
-  }}
+  defaultRelease="v2.0.2"
 />

--- a/docs/operators/finality_providers/fp_core_specs.mdx
+++ b/docs/operators/finality_providers/fp_core_specs.mdx
@@ -13,7 +13,7 @@ export const rawUrl="https://raw.githubusercontent.com/babylonlabs-io/finality-p
 <RemoteMD
   rawUrl={rawUrl}
   hideRelease={false}
-  defaultRelease="v1.0.0"
+  defaultRelease="v1.1.0-rc.1"
   releaseVersions={{
     "v1.1.0-rc.1": "https://raw.githubusercontent.com/babylonlabs-io/finality-provider/refs/tags/v1.1.0-rc.1/docs/fp-core.md", 
   }}

--- a/docs/operators/finality_providers/fp_finality_votes.mdx
+++ b/docs/operators/finality_providers/fp_finality_votes.mdx
@@ -13,7 +13,7 @@ export const rawUrl="https://raw.githubusercontent.com/babylonlabs-io/finality-p
 <RemoteMD
   rawUrl={rawUrl}
   hideRelease={false}
-  defaultRelease="v1.0.0"
+  defaultRelease="v1.1.0-rc.1"
   releaseVersions={{
     "v1.1.0-rc.1": "https://raw.githubusercontent.com/babylonlabs-io/finality-provider/refs/tags/v1.1.0-rc.1/docs/send-finality-vote.md", 
   }}

--- a/docs/operators/finality_providers/fp_finality_votes.mdx
+++ b/docs/operators/finality_providers/fp_finality_votes.mdx
@@ -13,8 +13,5 @@ export const rawUrl="https://raw.githubusercontent.com/babylonlabs-io/finality-p
 <RemoteMD
   rawUrl={rawUrl}
   hideRelease={false}
-  defaultRelease="v1.1.0-rc.1"
-  releaseVersions={{
-    "v1.1.0-rc.1": "https://raw.githubusercontent.com/babylonlabs-io/finality-provider/refs/tags/v1.1.0-rc.1/docs/send-finality-vote.md", 
-  }}
+  defaultRelease="v2.0.2"
 />

--- a/docs/operators/finality_providers/fp_operations.mdx
+++ b/docs/operators/finality_providers/fp_operations.mdx
@@ -13,8 +13,5 @@ export const rawUrl="https://raw.githubusercontent.com/babylonlabs-io/finality-p
 <RemoteMD
   rawUrl={rawUrl}
   hideRelease={false}
-  defaultRelease="v1.1.0-rc.1"
-  releaseVersions={{
-    "v1.1.0-rc.1": "https://raw.githubusercontent.com/babylonlabs-io/finality-provider/refs/tags/v1.1.0-rc.1/docs/finality-provider-operation.md", 
-  }}
+  defaultRelease="v2.0.2"
 />

--- a/docs/operators/finality_providers/fp_operations.mdx
+++ b/docs/operators/finality_providers/fp_operations.mdx
@@ -13,7 +13,7 @@ export const rawUrl="https://raw.githubusercontent.com/babylonlabs-io/finality-p
 <RemoteMD
   rawUrl={rawUrl}
   hideRelease={false}
-  defaultRelease="v1.0.0"
+  defaultRelease="v1.1.0-rc.1"
   releaseVersions={{
     "v1.1.0-rc.1": "https://raw.githubusercontent.com/babylonlabs-io/finality-provider/refs/tags/v1.1.0-rc.1/docs/finality-provider-operation.md", 
   }}

--- a/docs/operators/finality_providers/fp_public_randomness.mdx
+++ b/docs/operators/finality_providers/fp_public_randomness.mdx
@@ -13,8 +13,5 @@ export const rawUrl="https://raw.githubusercontent.com/babylonlabs-io/finality-p
 <RemoteMD
   rawUrl={rawUrl}
   hideRelease={false}
-  defaultRelease="v1.1.0-rc.1"
-  releaseVersions={{
-    "v1.1.0-rc.1": "https://raw.githubusercontent.com/babylonlabs-io/finality-provider/refs/tags/v1.1.0-rc.1/docs/commit-pub-rand.md", 
-  }}
+  defaultRelease="v2.0.2"
 />

--- a/docs/operators/finality_providers/fp_public_randomness.mdx
+++ b/docs/operators/finality_providers/fp_public_randomness.mdx
@@ -13,7 +13,7 @@ export const rawUrl="https://raw.githubusercontent.com/babylonlabs-io/finality-p
 <RemoteMD
   rawUrl={rawUrl}
   hideRelease={false}
-  defaultRelease="v1.0.0"
+  defaultRelease="v1.1.0-rc.1"
   releaseVersions={{
     "v1.1.0-rc.1": "https://raw.githubusercontent.com/babylonlabs-io/finality-provider/refs/tags/v1.1.0-rc.1/docs/commit-pub-rand.md", 
   }}

--- a/docs/operators/finality_providers/hmac_security.mdx
+++ b/docs/operators/finality_providers/hmac_security.mdx
@@ -13,7 +13,7 @@ export const rawUrl="https://raw.githubusercontent.com/babylonlabs-io/finality-p
 <RemoteMD
   rawUrl={rawUrl}
   hideRelease={false}
-  defaultRelease="v1.0.0"
+  defaultRelease="v1.1.0-rc.1"
   releaseVersions={{
     "v1.1.0-rc.1": "https://raw.githubusercontent.com/babylonlabs-io/finality-provider/refs/tags/v1.1.0-rc.1/docs/hmac-security.md", 
   }}

--- a/docs/operators/finality_providers/hmac_security.mdx
+++ b/docs/operators/finality_providers/hmac_security.mdx
@@ -13,8 +13,5 @@ export const rawUrl="https://raw.githubusercontent.com/babylonlabs-io/finality-p
 <RemoteMD
   rawUrl={rawUrl}
   hideRelease={false}
-  defaultRelease="v1.1.0-rc.1"
-  releaseVersions={{
-    "v1.1.0-rc.1": "https://raw.githubusercontent.com/babylonlabs-io/finality-provider/refs/tags/v1.1.0-rc.1/docs/hmac-security.md", 
-  }}
+  defaultRelease="v2.0.2"
 />

--- a/docs/operators/finality_providers/slashing_protection.mdx
+++ b/docs/operators/finality_providers/slashing_protection.mdx
@@ -13,7 +13,7 @@ export const rawUrl="https://raw.githubusercontent.com/babylonlabs-io/finality-p
 <RemoteMD
   rawUrl={rawUrl}
   hideRelease={false}
-  defaultRelease="v1.0.0"
+  defaultRelease="v1.1.0-rc.1"
   releaseVersions={{
     "v1.1.0-rc.1": "https://raw.githubusercontent.com/babylonlabs-io/finality-provider/refs/tags/v1.1.0-rc.1/docs/slashing-protection.md", 
   }}

--- a/docs/operators/finality_providers/slashing_protection.mdx
+++ b/docs/operators/finality_providers/slashing_protection.mdx
@@ -13,9 +13,6 @@ export const rawUrl="https://raw.githubusercontent.com/babylonlabs-io/finality-p
 <RemoteMD
   rawUrl={rawUrl}
   hideRelease={false}
-  defaultRelease="v1.1.0-rc.1"
-  releaseVersions={{
-    "v1.1.0-rc.1": "https://raw.githubusercontent.com/babylonlabs-io/finality-provider/refs/tags/v1.1.0-rc.1/docs/slashing-protection.md", 
-  }}
+  defaultRelease="v2.0.2"
 />
 

--- a/src/components/RemoteMD.jsx
+++ b/src/components/RemoteMD.jsx
@@ -195,7 +195,10 @@ export default function RemoteMD({
     }
 
     if (!initialKey && defaultRelease) {
-      initialKey = defaultRelease;
+      // Only use defaultRelease if it exists in the available releases
+      if (releases.some(r => r.key === defaultRelease)) {
+        initialKey = defaultRelease;
+      }
     }
 
     if (!initialKey && releases.length > 0) {


### PR DESCRIPTION
- Updated defaultRelease in multiple finality provider documentation files to v1.1.0-rc.1.
- Adjusted release versions and URLs accordingly for consistency across the documentation.

This change ensures that all references to the finality provider are aligned with the latest release candidate version.

Closes #404