### PR TITLE
fix(chat): auto-expire chat sessions older than two months

### DIFF
--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -38,7 +38,6 @@ interface ChatSession {
 }
 
 const STORAGE_KEY = 'babylon_ai_chat_sessions';
-const OLD_STORAGE_KEY = 'babylon_ai_chat_history'; // For migration
 const CONSENT_KEY = 'babylon_ai_chat_consent';
 
 const PRIVACY_CONSENT_TEXT =
@@ -77,36 +76,21 @@ export default function ChatWidget() {
     return false;
   });
 
-  // State for sessions
+  // State for sessions (with two-calendar-month expiry to match backend retention policy)
   const [sessions, setSessions] = useState<ChatSession[]>(() => {
     if (typeof window !== 'undefined') {
-      // Try new format first
       const savedSessions = localStorage.getItem(STORAGE_KEY);
       if (savedSessions) {
         try {
-          return JSON.parse(savedSessions);
+          const parsed: ChatSession[] = JSON.parse(savedSessions);
+          // Prune sessions older than two calendar months
+          const cutoff = new Date();
+          cutoff.setMonth(cutoff.getMonth() - 2);
+          const cutoffTs = cutoff.getTime();
+          const fresh = parsed.filter(s => s.timestamp >= cutoffTs);
+          if (fresh.length > 0) return fresh;
         } catch (e) {
           console.error('Failed to parse sessions', e);
-        }
-      }
-
-      // Migration: Check for old format
-      const oldHistory = localStorage.getItem(OLD_STORAGE_KEY);
-      if (oldHistory) {
-        try {
-          const messages = JSON.parse(oldHistory);
-          if (Array.isArray(messages) && messages.length > 0) {
-             const migratedSession: ChatSession = {
-               id: Date.now().toString(),
-               thread_uuid: generateUUID(), // Best effort migration
-               title: 'Previous Chat',
-               messages: messages,
-               timestamp: Date.now()
-             };
-             return [migratedSession];
-          }
-        } catch (e) {
-          console.error('Failed to migrate old history', e);
         }
       }
     }
@@ -265,7 +249,7 @@ export default function ChatWidget() {
     if (value.trim()) {
       const estimatedTokens = estimateTokens(value);
       if (estimatedTokens > maxTokens) {
-        setInputError(`Message too long (~${estimatedTokens}/${maxTokens} tokens).Please shorten your question.`);
+        setInputError(`Message too long (~${estimatedTokens}/${maxTokens} tokens). Please shorten your question.`);
       } else if (estimatedTokens > maxTokens * 0.8) {
         setInputError(`Approaching limit (~${estimatedTokens}/${maxTokens} tokens)`);
       } else {
@@ -290,12 +274,10 @@ export default function ChatWidget() {
     scrollToBottom();
   }, [messages, isOpen, isExpanded, currentSessionId]);
 
-  // Persist sessions
+  // Persist sessions (expired sessions pruned on load)
   useEffect(() => {
     if (typeof window !== 'undefined') {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(sessions));
-      // Clean up old key if exists
-      localStorage.removeItem(OLD_STORAGE_KEY);
     }
   }, [sessions]);
 


### PR DESCRIPTION
## Summary
- Chat sessions in `localStorage` now auto-expire after two calendar months, matching the
backend's data retention policy stated in the privacy consent text
- Removes legacy migration code for the old `babylon_ai_chat_history` storage key
- Fixes minor typo in token-limit error message (missing space)

## Test plan
- [ ] Open the site, send a chat message, close and reopen the tab — session persists
- [ ] Manually set a session's `timestamp` to >2 months ago in DevTools → reload → session is
pruned
- [ ] Verify consent flag (`babylon_ai_chat_consent`) still persists in `localStorage`
independently
- [ ] `npm run build` passes with no errors

Closes #402 

🤖 Generated with [Claude Code](https://claude.com/claude-code)