### PR TITLE
fix(gh-pages): use gha-s3-frontend-push role for build-artifacts upload

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ matrix.account }}:role/gha-deployment
-          role-session-name: gh-terragrunt-plan
+          role-to-assume: arn:aws:iam::${{ matrix.account }}:role/gha-s3-frontend-deployment
+          role-session-name: gha-s3-frontend-deployment
           aws-region: ${{ vars.AWS_ECR_REGION }}
 
       # Upload to S3

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ matrix.account }}:role/gha-s3-frontend-deployment
-          role-session-name: gha-s3-frontend-deployment
+          role-to-assume: arn:aws:iam::${{ matrix.account }}:role/gha-s3-frontend-push
+          role-session-name: gha-s3-frontend-push
           aws-region: ${{ vars.AWS_ECR_REGION }}
 
       # Upload to S3


### PR DESCRIPTION
## Summary

Fixes the AccessDenied on `s3:PutObject` seen in https://github.com/babylonlabs-io/babylonlabs.github.io/actions/runs/25421741158/job/74565284533 and https://github.com/babylonlabs-io/babylonlabs.github.io/actions/runs/24062970798/job/70182925956.

The previous role (`gha-s3-frontend-deployment`) is intentionally read-only on build-artifact buckets — those are listed under `BuildArtifactBucketNames` in the terraform config (read-only: GetObject, ListBucket only). Switching to `gha-s3-frontend-push`, which grants `s3:PutObject` on artifact buckets and intentionally omits `s3:DeleteObject` to prevent artifact tampering.

## Depends on

- babylonlabs-io/terraform#235 — adds this repo to the `gha-s3-frontend-push` trust policy (any-branch on dev / `main`-only on prd, mirroring the deployment role). Terraform must be applied before this PR is merged.

## Test plan

- [ ] terraform#235 merged and applied to dev + prd
- [ ] Re-run gh-pages workflow on `dev` branch → upload to `s3://devnet-dapp-frontend-build-artifacts/docs-website/<sha>.tar.gz` succeeds
- [ ] Merge to `main` → upload to `s3://mainnet-dapp-frontend-build-artifacts/docs-website/<sha>.tar.gz` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)