### PR TITLE
docs(tokenomics): apply 2026 lockup amendment to BABY unlock schedule

### DIFF
--- a/docs/guides/overview/babylon_genesis/baby_tokenomics.mdx
+++ b/docs/guides/overview/babylon_genesis/baby_tokenomics.mdx
@@ -49,9 +49,9 @@ be taken from other categories to be given to early team members, investors or a
 | Community Incentives | 1,500,000,000 | 15% | No | Fully unlocked |
 | Ecosystem Building | 1,800,000,000 | 18% | No | Yes, across 3 years |
 | R&D + Operations | 1,800,000,000 | 18% | No | Yes, across 3 years |
-| Early Private Investors | 3,050,000,000 | 30.5% | No | Yes, across 3 years |
-| Team | 1,500,000,000 | 15% | Yes, across 4 years | Yes, across 4 years |
-| Advisors | 350,000,000 | 3.5% | Yes | Yes, across 4 years |
+| Early Private Investors | 3,050,000,000 | 30.5% | No | Yes, 36 monthly unlocks from May 2026 through Apr 2029 |
+| Team | 1,500,000,000 | 15% | Yes, across 4 years | Yes, 36 monthly unlocks from May 2026 through Apr 2029 |
+| Advisors | 350,000,000 | 3.5% | Yes | Yes, 36 monthly unlocks from May 2026 through Apr 2029 |
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import ThemedImage from '@theme/ThemedImage';
@@ -93,36 +93,30 @@ BABY tokens from this allocation can be staked, and staking rewards will be attr
 back to this category.
 
 ### Early Private-Round Investors (30.5%)
-Early investors in Babylon are allocated 3.05 billion BABY tokens, following a 4-year 
-unlocking schedule. The first unlocking event occurs on the first anniversary of the 
-network launch, releasing 12.5% of the total allocation. The remaining tokens unlock 
-linearly over 3 years. Investors cannot stake locked tokens in the first year. After the 
-first year, the locked tokens can be staked.
+Early investors in Babylon are allocated 3.05 billion BABY tokens. Per the amended lockup 
+schedule announced by the Babylon Foundation, the first unlocking event occurs on 10 May 
+2026, releasing 1/36th of the locked tokens, followed by 35 additional monthly unlocks 
+of 1/36th each, ending in April 2029. Investors cannot stake locked tokens in the first 
+year following the network launch. After that, the locked tokens can be staked.
 
 ### Team (15%)
-1.5 billion BABY tokens are allocated to the core Babylon team members. These tokens 
-follow a 4-year vesting schedule, with a 1-year cliff followed by linear vesting of the 
-remaining 3 years. Unvested tokens cannot be staked.
+1.5 billion BABY tokens are allocated to current and former core Babylon team members. 
+These tokens follow a 4-year vesting schedule, with a 1-year cliff followed by linear 
+vesting of the remaining 3 years. Unvested tokens cannot be staked.
 
-Vested tokens are subject to a 4-year unlocking schedule. The first unlocking event occurs 
-on the first anniversary of the network launch, or one year service anniversary, whichever 
-is later. This first unlock releases 12.5% of the total allocation. The remaining tokens 
-unlock linearly over 3 years. Team members cannot stake locked tokens in the first year. 
-After that, the locked tokens can be staked.
+Per the amended lockup schedule announced by the Babylon Foundation, the first unlocking 
+event for vested tokens occurs on 10 May 2026, releasing 1/36th of the locked tokens, 
+followed by 35 additional monthly unlocks of 1/36th each, ending in April 2029. Team 
+members cannot stake locked tokens in the first year following the network launch. After 
+that, the locked tokens can be staked.
 
 ### Advisors (3.5%)
-350 million BABY tokens are allocated to advisors, following individual vesting schedules 
-and the same 4-year unlocking schedule as the team. Unvested tokens cannot be staked. 
-Advisors cannot stake locked tokens in the first year. After that, the locked tokens can 
-be staked.
-
-<ThemedImage
-  alt="BABY Token Unlocking Schedule"
-  sources={{
-    light: useBaseUrl('/img/guides/baby_token_unlocking_schedule.png'),
-    dark: useBaseUrl('/img/guides/baby_token_unlocking_schedule_dark.png'),
-  }}
-/>
+350 million BABY tokens are allocated to advisors, following individual vesting schedules. 
+Per the amended lockup schedule announced by the Babylon Foundation, the first unlocking 
+event occurs on 10 May 2026, releasing 1/36th of the locked tokens, followed by 35 
+additional monthly unlocks of 1/36th each, ending in April 2029. Unvested tokens cannot 
+be staked. Advisors cannot stake locked tokens in the first year following the network 
+launch. After that, the locked tokens can be staked.
 
 ## Legal Notice
 **THIS IS NOT AN OFFER TO SELL OR THE SOLICITATION OF AN OFFER TO PURCHASE ANY BABY, AND IS NOT AN OFFERING, ADVERTISEMENT, SOLICITATION, CONFIRMATION, STATEMENT OR ANY FINANCIAL PROMOTION THAT CAN BE CONSTRUED AS AN INVITATION OR INDUCEMENT TO ENGAGE IN ANY INVESTMENT ACTIVITY OR SIMILAR.**

--- a/docs/guides/overview/babylon_genesis/baby_tokenomics.mdx
+++ b/docs/guides/overview/babylon_genesis/baby_tokenomics.mdx
@@ -50,7 +50,7 @@ be taken from other categories to be given to early team members, investors or a
 | Ecosystem Building | 1,800,000,000 | 18% | No | Yes, across 3 years |
 | R&D + Operations | 1,800,000,000 | 18% | No | Yes, across 3 years |
 | Early Private Investors | 3,050,000,000 | 30.5% | No | Yes, 36 monthly unlocks from May 2026 through Apr 2029 |
-| Team | 1,500,000,000 | 15% | Yes, across 4 years | Yes, 36 monthly unlocks from May 2026 through Apr 2029 |
+| Team | 1,500,000,000 | 15% | Yes | Yes, 36 monthly unlocks from May 2026 through Apr 2029 |
 | Advisors | 350,000,000 | 3.5% | Yes | Yes, 36 monthly unlocks from May 2026 through Apr 2029 |
 
 import useBaseUrl from '@docusaurus/useBaseUrl';


### PR DESCRIPTION
## Summary
Apply the Babylon Foundation's 2026 amendment to the BABY token lockup schedule on the [BABY Tokenomics page](https://docs.babylonlabs.io/guides/overview/babylon_genesis/baby_tokenomics/).

The amendment **removes the 10 April 2026 cliff unlock of 12.5%** for team members, private-round investors, and advisors. The first unlock now happens on **10 May 2026 as 1/36th of the locked tokens**, followed by **35 additional monthly unlocks of 1/36th each, ending in April 2029**. Token distribution percentages are unchanged.

### Changes
- Rewrote the **Early Private-Round Investors**, **Team**, and **Advisors** section descriptions
- Updated **Team** copy to "current and former core Babylon team members" per the announcement wording
- Updated the **Unlocking** column in the distribution table to `Yes, 36 monthly unlocks from May 2026 through Apr 2029`
- **Removed** the `baby_token_unlocking_schedule` `<ThemedImage>` block — the old cliff+ramp shape contradicts the new monthly cadence

### Follow-up needed
- **New unlocking-schedule chart**: design owner (Lex) needs to produce an updated `baby_token_unlocking_schedule.png` / `_dark.png` reflecting the new May 2026 → Apr 2029 monthly ramp, then re-add the image block in a follow-up PR. The old PNGs remain in `static/img/guides/` for now but are no longer referenced.

### Review
- Reviewed by Codex (read-only sandbox): two passes — initial review surfaced 1 blocker (stale chart) and 2 medium drifts; all addressed in this PR. Final pass: **LGTM, no findings**.
- Diff is wording + table column + image-block removal only — no structural / config changes.

## Test plan
- [x] Local production build passes (`npm run build` on Node 22.22.2)
  - 402 HTML pages generated, 0 broken-link errors, exit code 0
  - Built page contains the new copy in all three sections + table
- [x] Local dev server (`npm run dev`) — page renders correctly with the new schedule, no orphaned `<ThemedImage>` references (distribution chart still shows)
- [x] Codex review pass
- [ ] CI build on PR (Node 22.3) — expected to pass
- [ ] Visual review on dev/preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)