### PR TITLE
Shorten TBV testnet guide headings

### DIFF
--- a/docs/trustless-bitcoin-vault/use-for-lending/create-a-vault.mdx
+++ b/docs/trustless-bitcoin-vault/use-for-lending/create-a-vault.mdx
@@ -83,7 +83,7 @@ You don't manage these paths directly. They are part of the pre-signed Taproot s
 
 If you chose the two-vault split, the portal broadcasts a single Pre-PegIn transaction with two HTLC outputs (one per vault), saving on Bitcoin fees and ensuring both vaults activate together.
 
-## Step 4: Wait for confirmations and off-chain setup
+## Step 4: Wait for confirmations & setup
 
 After submission, two processes run in parallel.
 
@@ -151,7 +151,7 @@ After the PegIn transaction confirms on Bitcoin, the vault is fully active. The 
 
 Activate within the 48-hour activation window. The window starts when you submit the peg-in request. If the vault is not activated before `pegInActivationTimeout` closes, the vault enters **Expired** state and BTC recovery moves to the refund path.
 
-## Step 9: After activation — vaultBTC is supplied automatically
+## Step 9: Post activation
 
 vaultBTC for the vault's BTC amount is **automatically minted and supplied** to your position on the Babylon Core Spoke (the Aave v4 market for vaultBTC) at activation. The manual action is the **Activate** transaction above; there is no separate mint or supply step. The vault's status moves to **InUse**; you can now [borrow stablecoins or WBTC](./borrow-and-repay.mdx) against it.
 

--- a/docs/trustless-bitcoin-vault/use-for-lending/faq.mdx
+++ b/docs/trustless-bitcoin-vault/use-for-lending/faq.mdx
@@ -28,12 +28,12 @@ Sepolia.
 For the current supported list, networks, and faucet links, see
 [Setup](/trustless-bitcoin-vault/testnet-info/setup/).
 
-### Why does the Bitcoin wallet need a Taproot address?
+### Why do I need a Taproot address?
 
 TBV locks BTC in a Taproot output. The wallet has to produce Taproot (P2TR)
 addresses to participate. Addresses of different types do not share balance.
 
-### I cannot connect my wallets. What should I check?
+### I cannot connect my wallets, what next?
 
 1. The UniSat Bitcoin wallet is set to signet, not mainnet.
 2. The Ethereum wallet is on Sepolia (chain ID `11155111`), not another network.
@@ -66,7 +66,7 @@ minutes once confirmations land. Activation itself is one Ethereum transaction.
 For the stage-by-stage breakdown, see
 [Create a vault](/trustless-bitcoin-vault/use-for-lending/create-a-vault/).
 
-### Why does the app recommend splitting BTC into two vaults?
+### Why splitting BTC into two vaults?
 
 Each vault is a single Bitcoin UTXO and cannot be partially seized. With one
 vault, liquidation seizes the whole vault. With two correctly-sized vaults, the
@@ -138,7 +138,7 @@ Both prompts are standard ERC-20 behaviour, not specific to TBV.
 Yes. The Aave Adapter accepts repayments from any address; the debt simply
 decreases on the position regardless of who paid.
 
-### Why is my borrow rate or remaining debt different from what I expected?
+### Why is my borrow rate different?
 
 A few common causes:
 
@@ -209,7 +209,7 @@ For a full withdrawal, debt must be zero on every borrowed reserve: USDC, USDT,
 and WBTC. A single satoshi of remaining debt on any reserve blocks a full
 withdrawal.
 
-### Why does the dashboard still show Pending Withdraw after the wallet confirms?
+### Why does the dashboard still show Pending Withdraw?
 
 The Ethereum transaction only starts redemption. After it confirms, the protocol
 runs the Bitcoin-side claim, the assert, and the challenge-window wait before
@@ -272,7 +272,7 @@ alongside the wallet seed phrase.
 Signet block times can be irregular. Slow confirmations are usually a property
 of the network, not of the protocol.
 
-### What if I refresh the page or cancel a wallet signature mid-flow?
+### What if I refresh the page while signing?
 
 The flow is resumable. Reopen the portal with the same Bitcoin and Ethereum
 wallets used for the in-flight vault. Refresh once and look for any pending

--- a/docs/trustless-bitcoin-vault/use-for-lending/liquidation-risk.mdx
+++ b/docs/trustless-bitcoin-vault/use-for-lending/liquidation-risk.mdx
@@ -64,7 +64,7 @@ The portal recommends splitting your BTC into two vaults at peg-in: a **sacrific
 
 The sacrificial vault's size depends on the target health factor (THF) and other protocol parameters. The portal computes the recommended split dynamically from the on-chain values.
 
-### Worked example with public-testnet parameters
+### A worked example
 
 Suppose you peg in the public-testnet maximum and split it as recommended. With THF = 1.24, CF = 78%, max LB = 10%, and a typical worst-case health factor at liquidation of ~0.97:
 
@@ -78,7 +78,7 @@ Without the split, the same liquidation seizes the full single vault. That is th
 
 You can reorder vaults after creation. If price action changes which vault is the right sacrificial buffer, reorder it before the position becomes unhealthy. See [Create a vault](/trustless-bitcoin-vault/use-for-lending/create-a-vault/) for the two-vault setup at peg-in.
 
-## Fairness payment: you do not lose the excess
+## Fairness payment
 
 Because vaults are indivisible, the seized vault almost always carries slightly more BTC than a perfectly divisible partial liquidation would have taken. The **fairness mechanism** returns the excess to you.
 

--- a/docs/trustless-bitcoin-vault/use-for-lending/quickstart.mdx
+++ b/docs/trustless-bitcoin-vault/use-for-lending/quickstart.mdx
@@ -29,7 +29,7 @@ You need:
 
 For the full list of supported wallets, network and RPC details, and faucet URLs, see [Setup](../testnet-info/setup.mdx).
 
-## Step 1: Open the Aave v4 Lending Dashboard
+## Step 1: Open the Aave v4 Lending
 
 Navigate to the Aave v4 Lending Dashboard URL listed in [Setup](../testnet-info/setup.mdx).
 
@@ -69,7 +69,7 @@ When the vault reaches **Verified** status, the app prompts you to **Activate**.
 
 ![Active vault in the Collateral section](/img/trustless-bitcoin-vault/use-for-lending/quickstart-06-activate-prompt.png)
 
-## Step 4: Borrow stablecoins (Aave v4 application layer)
+## Step 4: Borrow stablecoins
 
 Your vault is already supplied as collateral on the integrated Aave v4 market — minted and supplied automatically when you activated. From this step on, you are interacting with the Aave v4 application layer; the underlying vault on Bitcoin sits unchanged.
 
@@ -95,7 +95,7 @@ Open the **Loans** section and click **Borrow**:
 
 The borrowed asset arrives in your Ethereum wallet. The app now shows your **health factor**, a single number summarizing how close the position is to liquidation. A higher number is safer.
 
-## Step 5: Repay the debt (Aave v4 application layer)
+## Step 5: Repay the debt
 
 To close the position, repay what you borrowed.
 
@@ -116,7 +116,7 @@ Repaying usually shows an ERC-20 spending cap approval first, then the repayment
 
 Interest accrues continuously until repayment, so the exact amount due is slightly higher than the principal borrowed. After full repayment, the vault is eligible for redemption.
 
-## Step 6: Withdraw and redeem the BTC (peg-out — TBV protocol layer)
+## Step 6: Withdraw and redeem
 
 Redeeming releases the underlying BTC from the vault back to your Bitcoin wallet. This step crosses back from the Aave v4 application layer into the TBV protocol layer.
 

--- a/docs/trustless-bitcoin-vault/use-for-lending/withdraw-and-redeem.mdx
+++ b/docs/trustless-bitcoin-vault/use-for-lending/withdraw-and-redeem.mdx
@@ -29,7 +29,7 @@ Check the following on your position:
 
 The portal surfaces all three of these on the Loans section. For programmatic access, query `getUserAccountData()` on the Babylon Core Spoke through your proxy address to read current debt, collateral value, and health factor in one call.
 
-## Step 1: Repay your debt (Aave v4 application)
+## Step 1: Repay your debt
 
 If you have any outstanding debt, repay it before attempting a full withdrawal. For each borrowed reserve:
 
@@ -39,7 +39,7 @@ If you have any outstanding debt, repay it before attempting a full withdrawal. 
 
 Clear debt on every reserve you have borrowed from. A single satoshi of remaining debt on any reserve blocks a full withdrawal. For the full repayment flow, see [Borrow & repay](./borrow-and-repay.mdx).
 
-## Step 2: Withdraw collateral and start redemption (application → protocol handoff)
+## Step 2: Withdraw collateral and start redemption
 
 With debt cleared (full exit) or a healthy buffer left in place (partial exit), call `withdrawCollaterals(bytes32[] vaultsToWithdraw)` on the AaveAdapter with the list of vault IDs to remove. This step is the handoff from the Aave application layer to the TBV protocol layer: the AaveAdapter releases the vaults, and the TBV protocol takes over the Bitcoin-side redemption from here.
 
@@ -75,7 +75,7 @@ From the portal:
 
 From the depositor's point of view, `withdrawCollaterals` is a single transaction that removes vaults from the lending position and starts the Bitcoin claim.
 
-## Step 3: Wait through the challenge period (TBV protocol)
+## Step 3: Wait for the challenge period
 
 After redemption starts on Ethereum, the Vault Provider drives the Bitcoin side. Bitcoin cannot natively verify Ethereum state, so the protocol uses a ZK proof of the burn event, verified on Bitcoin via Babylon's BABE construction. This step is protocol-level — the same flow applies regardless of which application released the vault. The flow on Bitcoin runs in four steps:
 


### PR DESCRIPTION
## Summary
- Shorten overflow-prone TBV testnet FAQ and walkthrough headings
- Keep the underlying guide content unchanged

## Validation
- npm run build passed locally
- Existing build warnings observed: remote doc 404 for Babylon release/v3.x, deprecated Docusaurus markdown config, stale Browserslist data, and existing ignored redirect entries