### PR TITLE
 fix(ci): select Algolia index from matrix environment, not trigger ref

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -41,17 +41,6 @@ jobs:
           node-version: '22.3'
           cache: 'npm'
 
-      - name: Extract branch name
-        id: extract_branch
-        run: |
-          if [[ "${GITHUB_REF}" == "refs/heads/"* ]]; then
-            echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-          elif [[ "${GITHUB_REF}" == "refs/pull/"* ]]; then
-            echo "BRANCH_NAME=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
-          else
-            echo "BRANCH_NAME=unknown" >> $GITHUB_ENV
-          fi
-
       # Navigate to the correct working directory and install dependencies
       - name: Install dependencies
         working-directory: ./
@@ -63,7 +52,11 @@ jobs:
         env:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_API_KEY_READONLY: ${{ secrets.ALGOLIA_API_KEY_READONLY }}
-          BRANCH_NAME: ${{ env.BRANCH_NAME }}
+          # Select the Algolia index from the target environment (matrix.branch),
+          # not the triggering git ref. Each matrix job builds the artifact for a
+          # specific environment/bucket, so the index must match that environment:
+          # main -> production index, dev -> dev index.
+          BRANCH_NAME: ${{ matrix.branch }}
           TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
           API_BASE_URL: ${{ vars.API_BASE_URL }}
         run: |


### PR DESCRIPTION
  The build matrix runs both the dev and production jobs on every push
  and
  uploads each to its own S3 bucket. BRANCH_NAME (which picks the
  Algolia
  index) was derived from the triggering git ref, so both jobs used the
  same
  value: a push to main built the dev artifact with BRANCH_NAME=main,
  giving
  the dev site the production index (and vice versa for pushes to dev).

  Set BRANCH_NAME from matrix.branch so each environment's artifact is
  always
  built with its matching index, and drop the now-unused extract_branch
  step.