### PR TITLE
 docs(tbv): remove compromised Telegram community link

### DIFF
--- a/docs/trustless-bitcoin-vault/reference/community-and-support.mdx
+++ b/docs/trustless-bitcoin-vault/reference/community-and-support.mdx
@@ -14,7 +14,6 @@ Where to ask questions, follow announcements, file issues, or reach the team abo
 | --- | --- | --- |
 | General questions, chat with the community, get help while using the TBV Testnet app | Discord | [discord.gg/qwTzSmtP](https://discord.gg/qwTzSmtP) |
 | Announcements, release notes, status updates | Twitter / X | [@babylonlabs_io](https://x.com/babylonlabs_io) |
-| Real-time chat (alternative to Discord) | Telegram | [t.me/babyloncommunity](https://t.me/babyloncommunity) |
 | Source code, issue tracker, SDK | GitHub | [github.com/babylonlabs-io](https://github.com/babylonlabs-io) |
 | Partnership and press inquiries | Email | [bd@babylonlabs.io](mailto:bd@babylonlabs.io) |
 | Security Council recovery (lost self-claim inputs while VP is unresponsive) | Discord or partnership email | Reach the team via the channels above and request Security Council escalation |


### PR DESCRIPTION
  The babyloncommunity Telegram group is no longer controlled by the
  team —
  the founder's account (the group owner) was compromised. Remove the
  link
  from the TBV community & support channels table to avoid directing
  users to an uncontrolled group.