### PR TITLE
docs(tbv): hide Technical Details + Safety pages pending corrections

### DIFF
--- a/docs/trustless-bitcoin-vault/start-here/safety-and-trust-assumptions.mdx
+++ b/docs/trustless-bitcoin-vault/start-here/safety-and-trust-assumptions.mdx
@@ -1,6 +1,7 @@
 ---
 title: Safety & trust assumptions
 sidebar_position: 4
+draft: true
 ---
 
 # Safety & trust assumptions

--- a/docs/trustless-bitcoin-vault/technical-details/aave-v4-integration.mdx
+++ b/docs/trustless-bitcoin-vault/technical-details/aave-v4-integration.mdx
@@ -1,6 +1,7 @@
 ---
 title: Aave v4 integration
 sidebar_position: 3
+draft: true
 ---
 
 # Aave v4 integration

--- a/docs/trustless-bitcoin-vault/technical-details/protocol-actors.mdx
+++ b/docs/trustless-bitcoin-vault/technical-details/protocol-actors.mdx
@@ -1,6 +1,7 @@
 ---
 title: Protocol actors
 sidebar_position: 2
+draft: true
 ---
 
 # Protocol actors

--- a/docs/trustless-bitcoin-vault/technical-details/protocol-architecture.mdx
+++ b/docs/trustless-bitcoin-vault/technical-details/protocol-architecture.mdx
@@ -1,6 +1,7 @@
 ---
 title: Protocol architecture
 sidebar_position: 1
+draft: true
 ---
 
 # Protocol architecture

--- a/sidebars-default.js
+++ b/sidebars-default.js
@@ -265,7 +265,6 @@ const sidebars = {
         'trustless-bitcoin-vault/start-here/what-is-tbv',
         'trustless-bitcoin-vault/start-here/how-it-works',
         'trustless-bitcoin-vault/start-here/tbv-vs-alternatives',
-        'trustless-bitcoin-vault/start-here/safety-and-trust-assumptions',
       ],
     },
     {
@@ -293,18 +292,6 @@ const sidebars = {
         'trustless-bitcoin-vault/use-for-lending/withdraw-and-redeem',
         'trustless-bitcoin-vault/use-for-lending/liquidation-risk',
         'trustless-bitcoin-vault/use-for-lending/faq',
-      ],
-    },
-    {
-      type: 'category',
-      label: 'Technical Details',
-      collapsible: true,
-      collapsed: true,
-      className: 'specs_sidebar_header',
-      items: [
-        'trustless-bitcoin-vault/technical-details/protocol-architecture',
-        'trustless-bitcoin-vault/technical-details/protocol-actors',
-        'trustless-bitcoin-vault/technical-details/aave-v4-integration',
       ],
     },
     {


### PR DESCRIPTION
## Summary

Temporarily hides four Phase-2 TBV testnet pages (merged in #443) from the published site. They are held until Vlad provides corrections.

Pages hidden:
- `technical-details/protocol-architecture`
- `technical-details/protocol-actors`
- `technical-details/aave-v4-integration`
- `start-here/safety-and-trust-assumptions`

## How

- Added `draft: true` to each page's frontmatter → Docusaurus **excludes them from the production build**, so they 404 on docs.babylonlabs.io (and docs-dev).
- Removed the "Technical Details" sidebar category and the "Safety & trust assumptions" entry from `sidebars-default.js`.

## Reversible

To bring them back once corrections land: remove the `draft: true` flags and restore the two sidebar references. The content itself is untouched.

## Verification

- No other docs link to these four pages (only cross-links among themselves), so nothing dangles.
- Production build (`NODE_ENV=production docusaurus build`, `onBrokenLinks: 'throw'`) passes; the four `index.html` routes are confirmed absent from `build/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)