### PR TITLE
docs(tbv): Vault Indexer GraphQL API section + API navigation move

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,7 +13,24 @@ permissions:
   contents: read
 
 jobs:
+  verify-vault-indexer:
+    name: Verify Vault Indexer GraphQL examples
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0 https://github.com/actions/setup-node/releases/tag/v4.4.0
+        with:
+          node-version: '22.3'
+
+      - name: Execute every GraphQL example against testnet
+        run: npm run verify:vault-indexer-queries
+
   build:
+    needs: verify-vault-indexer
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/docs/trustless-bitcoin-vault/apis/_category_.json
+++ b/docs/trustless-bitcoin-vault/apis/_category_.json
@@ -1,0 +1,10 @@
+{
+  "label": "APIs",
+  "position": 4,
+  "collapsible": true,
+  "collapsed": true,
+  "link": {
+    "type": "generated-index",
+    "description": "Public APIs for Trustless Bitcoin Vault testnet: the vault indexer GraphQL endpoint, its schema, worked queries, and request limits."
+  }
+}

--- a/docs/trustless-bitcoin-vault/apis/limits-and-gotchas.mdx
+++ b/docs/trustless-bitcoin-vault/apis/limits-and-gotchas.mdx
@@ -153,17 +153,38 @@ At most **15** aliases per operation. Status breakdowns are the usual place to
 hit this — split into several requests rather than aliasing every enum value at
 once.
 
-## Two ways the API says "no"
+## Sustained bursts get a 429
+
+**Symptom:** HTTP **429** after a run of rapid back-to-back requests. There is no
+GraphQL body, so it looks like the endpoint has gone down.
+
+**Cause:** the edge throttles sustained bursts. A handful of requests is fine —
+we saw this only after several dozen queries fired with no gap. It clears within
+seconds.
+
+**Fix:** treat 429 and 5xx as retryable, with exponential backoff, and honour
+`Retry-After` when it is present. Never retry a **GraphQL** error: that means
+your query is wrong, and retrying only hides it.
+
+This distinction matters most in automation. A verification job that sends every
+example on a page one after another will meet this, and a job that cannot tell a
+throttle from a bad field will report a perfectly good query as broken.
+
+## Three ways the API says "no"
 
 They fail differently, and the difference tells you where to look.
 
 | Failure | Shape | Meaning |
 | --- | --- | --- |
 | Depth, token or alias limit | `Syntax Error: …` — the whole operation is rejected before execution | Your query's **shape** is too large |
-| `limit` over 1000 | Per-path error with `data: null` | One **resolver argument** is invalid |
+| `limit` over 1000 | Per-path error with `data: null`, HTTP 200 | One **resolver argument** is invalid |
+| Burst throttling | HTTP 429, no GraphQL body | Your **rate** is too high — back off and retry |
 
 The first is a query-shape guard applied before execution. The second is a
-per-resolver pagination guard.
+per-resolver pagination guard. The third is at the edge, before the API sees the
+request at all — which is why it carries no GraphQL error.
+
+Only the third is worth retrying.
 
 ## Known data gaps
 

--- a/docs/trustless-bitcoin-vault/apis/limits-and-gotchas.mdx
+++ b/docs/trustless-bitcoin-vault/apis/limits-and-gotchas.mdx
@@ -1,7 +1,7 @@
 ---
 title: Limits and Gotchas
 sidebar_label: Limits and Gotchas
-sidebar_position: 4
+sidebar_position: 5
 description: Request limits, the 403 user-agent trap, introspection constraints and known data gaps on the Babylon vault indexer.
 ---
 

--- a/docs/trustless-bitcoin-vault/apis/limits-and-gotchas.mdx
+++ b/docs/trustless-bitcoin-vault/apis/limits-and-gotchas.mdx
@@ -203,6 +203,30 @@ Accurate as of the last schema sync.
 - **`feeConfig` is empty.** It returns `totalCount: 0`, while `vaultFeeEscrow`
   holds one row per vault. Escrow records exist without a corresponding fee
   configuration row. Do not treat an empty `feeConfig` as an error.
+- **Three `vaultActivityType` values are never written.** `withdrawal`,
+  `add_collateral` and `remove_collateral` are declared in the enum, but no
+  indexer code path emits them, so filtering on any of the three returns
+  `totalCount: 0` permanently. That is not a sync delay, and it will not fill in
+  later without an indexer change. In particular, a vault reaching
+  `depositor_withdrawn` produces **no** `withdrawal` row, and collateral moving
+  in or out of an Aave position produces **no** `add_collateral` or
+  `remove_collateral` row. Read `aavePositionCollateral` for collateral state
+  instead — a row with `removedAt: null` is still pledged.
+- **`vaultActivity.vaultId` is null on `borrow` and `repay` rows.** This is by
+  design, not missing data: those events belong to an Aave position rather than
+  to a single vault. They carry a non-null `debtReserveId` instead. Do not
+  filter activity by `vaultId` and expect loan history to appear.
+- **`amount` on `vaultActivity` is not always satoshis.** On `borrow` and
+  `repay` it is denominated in the debt asset. Resolve `debtReserveId` against
+  `aaveReserve` for the decimals before formatting, or a USDT repayment will
+  render as an implausible quantity of BTC.
+- **A `deposit` row appears only once a vault becomes available.** The count
+  tracks vaults that reached `available` at some point, so it is much lower than
+  the total vault count. Vaults that expired before activation never produce
+  one.
+- **`claimExpiredUntil` is a block number, not a timestamp**, despite sitting
+  among timestamp fields. The contract sets it to the expiry block plus a grace
+  period. Compare it against `_meta`'s block number, never against a clock.
 - **The deployed schema can trail the indexer source.** Entities present in the
   indexer repository are not necessarily deployed. The
   [Schema Reference](./schema-reference.mdx) and the committed SDL are generated from

--- a/docs/trustless-bitcoin-vault/apis/limits-and-gotchas.mdx
+++ b/docs/trustless-bitcoin-vault/apis/limits-and-gotchas.mdx
@@ -1,0 +1,193 @@
+---
+title: Limits and Gotchas
+sidebar_label: Limits and Gotchas
+sidebar_position: 4
+description: Request limits, the 403 user-agent trap, introspection constraints and known data gaps on the Babylon vault indexer.
+---
+
+# Limits and Gotchas
+
+Read this before writing a client. Two of the items here fail in ways that point
+you at the wrong cause.
+
+## Request limits
+
+The deployment sets tighter limits than the indexer framework's defaults.
+
+| Limit | Value | Framework default |
+| --- | --- | --- |
+| Max operation depth | **10** | 100 |
+| Max operation tokens | **500** | 1000 |
+| Max operation aliases | **15** | 30 |
+| Max `limit` per page | **1000** | — |
+
+These bound the cost a single client can impose. Design around them rather than
+against them.
+
+## The 403 trap
+
+**Symptom:** a bare HTTP **403** with no GraphQL error body. It looks like an
+outage, an IP block or a missing API key. It is none of those.
+
+**Cause:** the edge rejects default library user-agents. `Python-urllib/3.11`
+gets a 403; a custom string gets a 200.
+
+**Fix:** always send your own `User-Agent`.
+
+```python
+import json, urllib.request
+
+req = urllib.request.Request(
+    "https://babylon-vault-indexer-api.testnet.babylonlabs.io/",
+    data=json.dumps({"query": "{ statss(limit:1){ items{ availableVaultCount } } }"}).encode(),
+    headers={
+        "Content-Type": "application/json",
+        "User-Agent": "my-app/1.0",  # required — the default gets a 403
+    },
+)
+print(json.load(urllib.request.urlopen(req)))
+```
+
+The same applies to `requests`, `httpx`, Go's `net/http` and any other client
+that sends a recognisable default.
+
+## Introspection is capped, not disabled
+
+**Symptom:** GraphiQL shows `Error fetching schema`. Apollo Sandbox, Postman,
+Insomnia and `graphql-codegen` all fail to load the schema.
+
+**Cause:** the standard `getIntrospectionQuery()` those tools send is **depth
+21**, and the cap is 10. The server replies:
+
+```
+Syntax Error: Query depth limit of 10 exceeded, found 21.
+```
+
+Introspection itself works. Only the standard query is too deep.
+
+**Fix — three options, easiest first.**
+
+**1. Use the committed schema.** This site ships the full SDL at
+[`/schema/vault-indexer.graphql`](/schema/vault-indexer.graphql). Point codegen
+at that file instead of the endpoint. This is what most builders should do.
+
+**2. Browse the [Schema Reference](./schema-reference.mdx)** for field names.
+
+**3. Introspect with shallower queries.** List every type at depth 4:
+
+```graphql
+{
+  __schema {
+    types {
+      kind
+      name
+    }
+  }
+}
+```
+
+Read one type's fields:
+
+```graphql
+{
+  __type(name: "vault") {
+    name
+    fields {
+      name
+      type {
+        kind
+        name
+        ofType {
+          kind
+          name
+        }
+      }
+    }
+  }
+}
+```
+
+Four such queries — enum values, field types, field arguments, and input fields —
+reconstruct the whole schema. The docs site regenerates its schema page exactly
+this way.
+
+:::note A correction
+Earlier internal tooling recorded that "introspection is disabled" on this
+endpoint. That is not accurate. Introspection is **depth-capped**. The queries
+above work today.
+:::
+
+## Pagination
+
+`limit` above 1000 is rejected per resolver, not per operation:
+
+```json
+{
+  "errors": [{ "message": "Invalid limit. Got 1001, expected <=1000." }],
+  "data": null
+}
+```
+
+Note `data` is `null` while the HTTP status stays 200. Check the `errors` key;
+do not rely on the status code alone.
+
+Page with `offset`, and always pass a stable `orderBy`. Without one, rows can
+repeat or disappear between pages.
+
+```graphql
+{
+  vaults(orderBy: "pendingAt", orderDirection: "asc", limit: 1000, offset: 0) {
+    totalCount
+    items {
+      id
+    }
+  }
+}
+```
+
+Stop when the rows you have collected reach `totalCount`.
+
+## Aliases
+
+At most **15** aliases per operation. Status breakdowns are the usual place to
+hit this — split into several requests rather than aliasing every enum value at
+once.
+
+## Two ways the API says "no"
+
+They fail differently, and the difference tells you where to look.
+
+| Failure | Shape | Meaning |
+| --- | --- | --- |
+| Depth, token or alias limit | `Syntax Error: …` — the whole operation is rejected before execution | Your query's **shape** is too large |
+| `limit` over 1000 | Per-path error with `data: null` | One **resolver argument** is invalid |
+
+The first is a query-shape guard applied before execution. The second is a
+per-resolver pagination guard.
+
+## Known data gaps
+
+Accurate as of the last schema sync.
+
+- **`feeConfig` is empty.** It returns `totalCount: 0`, while `vaultFeeEscrow`
+  holds one row per vault. Escrow records exist without a corresponding fee
+  configuration row. Do not treat an empty `feeConfig` as an error.
+- **The deployed schema can trail the indexer source.** Entities present in the
+  indexer repository are not necessarily deployed. The
+  [Schema Reference](./schema-reference.mdx) and the committed SDL are generated from
+  the **deployed** endpoint, so they are the accurate source. Anything absent
+  there does not exist in production, whatever the source repository shows.
+
+## Freshness
+
+The indexer trails the chain head. Check before trusting a result:
+
+```graphql
+{
+  _meta {
+    status
+  }
+}
+```
+
+`status` carries the last processed block number and timestamp per chain.

--- a/docs/trustless-bitcoin-vault/apis/limits-and-gotchas.mdx
+++ b/docs/trustless-bitcoin-vault/apis/limits-and-gotchas.mdx
@@ -68,7 +68,7 @@ Introspection itself works. Only the standard query is too deep.
 **Fix — three options, easiest first.**
 
 **1. Use the committed schema.** This site ships the full SDL at
-[`/schema/vault-indexer.graphql`](/schema/vault-indexer.graphql). Point codegen
+[`/schema/vault-indexer.graphql`](pathname:///schema/vault-indexer.graphql). Point codegen
 at that file instead of the endpoint. This is what most builders should do.
 
 **2. Browse the [Schema Reference](./schema-reference.mdx)** for field names.
@@ -119,6 +119,11 @@ above work today.
 
 ## Pagination
 
+**Omit `limit` and you get 50 rows, not all of them.** The response still
+reports the full `totalCount`, so a client that ignores `limit` looks like it
+succeeded while holding 50 of several thousand records. Always set `limit`
+explicitly, and always compare what you collected against `totalCount`.
+
 `limit` above 1000 is rejected per resolver, not per operation:
 
 ```json
@@ -146,6 +151,11 @@ repeat or disappear between pages.
 ```
 
 Stop when the rows you have collected reach `totalCount`.
+
+Every plural resolver also accepts cursors. Read `pageInfo { hasNextPage
+endCursor }` and pass `endCursor` back as `after` for the next page. Pick one
+style and keep to it: when you pass `offset`, `startCursor` and `endCursor`
+both come back `null`, so the two cannot be mixed within a single sweep.
 
 ## Aliases
 

--- a/docs/trustless-bitcoin-vault/apis/query-cookbook.mdx
+++ b/docs/trustless-bitcoin-vault/apis/query-cookbook.mdx
@@ -1,7 +1,7 @@
 ---
 title: Query Cookbook
 sidebar_label: Query Cookbook
-sidebar_position: 3
+sidebar_position: 4
 description: Worked, tested GraphQL queries for the Babylon vault indexer, grouped by who is asking.
 ---
 

--- a/docs/trustless-bitcoin-vault/apis/query-cookbook.mdx
+++ b/docs/trustless-bitcoin-vault/apis/query-cookbook.mdx
@@ -81,8 +81,14 @@ page size.
 
 A vault moves through `pending` → `signatures_collected` → `verified` →
 `available`, then to one of `redeemed`, `liquidated`, `expired`,
-`depositor_withdrawn` or `invalid`. The matching timestamp field tells you when
-each step happened.
+`depositor_withdrawn` or `invalid`.
+
+The timestamps above date the first four states and `expired`
+(`signatures_collected` is dated by `peginSigsPostedAt`, `available` by
+`activatedAt`). The vault record carries no timestamp for `redeemed`,
+`liquidated`, `depositor_withdrawn` or `invalid`. Date a redemption or a
+liquidation from `vaultActivity` instead, and treat `status` as the authority
+in every case.
 
 ### Check my Aave position and its collateral
 
@@ -288,9 +294,17 @@ pages.
 
 ### Filter operators
 
-Every scalar field gets a family of suffixed filters — `_not`, `_in`,
-`_not_in`, `_gt`, `_gte`, `_lt`, `_lte`, and for strings `_contains`,
-`_starts_with`, `_ends_with`. Combine them with `AND` and `OR`.
+Which suffixed filters a field accepts depends on its type. Every field takes
+the exact value, `_not`, `_in` and `_not_in`. Beyond that:
+
+| Field type | Extra operators |
+| --- | --- |
+| `BigInt`, `Int` | `_gt`, `_gte`, `_lt`, `_lte` |
+| `String` | `_contains`, `_starts_with`, `_ends_with`, each with a `_not_` form |
+| `Boolean`, enums | none |
+
+Strings get no ordering operators — `depositor_gt` is not a field, and asking
+for it fails validation. Combine filters with `AND` and `OR`.
 
 ```graphql
 {
@@ -299,7 +313,7 @@ Every scalar field gets a family of suffixed filters — `_not`, `_in`,
       AND: [
         { status: available }
         { amount_gte: "1000000" }
-        { inUse: false }
+        { inUse: true }
       ]
     }
     orderBy: "amount"
@@ -384,5 +398,5 @@ To read one type's fields without tripping the cap:
 
 Four such queries reconstruct the entire schema. The docs site ships the result
 already assembled at
-[`/schema/vault-indexer.graphql`](/schema/vault-indexer.graphql), so most builders
+[`/schema/vault-indexer.graphql`](pathname:///schema/vault-indexer.graphql), so most builders
 never need to introspect at all.

--- a/docs/trustless-bitcoin-vault/apis/query-cookbook.mdx
+++ b/docs/trustless-bitcoin-vault/apis/query-cookbook.mdx
@@ -130,6 +130,7 @@ A `removedAt` of `null` means the collateral is still pledged.
       type
       amount
       vaultId
+      debtReserveId
       timestamp
       transactionHash
     }
@@ -137,8 +138,18 @@ A `removedAt` of `null` means the collateral is still pledged.
 }
 ```
 
-`type` is one of `deposit`, `withdrawal`, `add_collateral`, `remove_collateral`,
-`liquidation`, `borrow`, `repay`, `redeem`, `claim_expired`.
+In practice `type` is one of `deposit`, `borrow`, `repay`, `redeem`,
+`liquidation` or `claim_expired`. The enum also declares `withdrawal`,
+`add_collateral` and `remove_collateral`, but nothing writes those, so they
+never appear. See [Known data gaps](./limits-and-gotchas.mdx).
+
+Two things to handle when you render these rows:
+
+- `vaultId` is `null` on `borrow` and `repay`. Those events belong to an Aave
+  position, not to one vault.
+- `amount` is in satoshis **except** on `borrow` and `repay`, where it is in the
+  debt asset. Resolve `debtReserveId` against `aaveReserve` for the symbol and
+  decimals before formatting.
 
 ---
 

--- a/docs/trustless-bitcoin-vault/apis/query-cookbook.mdx
+++ b/docs/trustless-bitcoin-vault/apis/query-cookbook.mdx
@@ -1,0 +1,388 @@
+---
+title: Query Cookbook
+sidebar_label: Query Cookbook
+sidebar_position: 3
+description: Worked, tested GraphQL queries for the Babylon vault indexer, grouped by who is asking.
+---
+
+# Query Cookbook
+
+Every query on this page is executed against the live testnet endpoint in CI. If
+one stops working, the build fails.
+
+Copy any of them into the [explorer](https://babylon-vault-indexer-api.testnet.babylonlabs.io/)
+or send them with `curl`. Addresses in the examples are real testnet records, so
+they return data as written.
+
+:::warning Set a User-Agent
+The endpoint sits behind Cloudflare, which rejects default library user-agents
+with a bare **403** and no GraphQL error body. Always set your own. See
+[Limits and gotchas](./limits-and-gotchas.mdx).
+:::
+
+```bash
+curl -s https://babylon-vault-indexer-api.testnet.babylonlabs.io/ \
+  -H 'Content-Type: application/json' \
+  -H 'User-Agent: my-app/1.0' \
+  -d '{"query":"{ statss(limit:1){ items{ totalAvailableSats availableVaultCount } } }"}'
+```
+
+---
+
+## For depositors and borrowers
+
+### Find all my vaults
+
+Filter by your depositor address. `totalCount` is the full match count, not the
+page size.
+
+```graphql
+{
+  vaults(
+    where: { depositor: "0x106d71c740aeebf6e72f06dad4129651dc65d810" }
+    orderBy: "pendingAt"
+    orderDirection: "desc"
+    limit: 10
+  ) {
+    totalCount
+    items {
+      id
+      status
+      amount
+      activatedAt
+      inUse
+    }
+  }
+}
+```
+
+`amount` is in satoshis, returned as a string because it is a `BigInt`.
+
+### Inspect one vault
+
+```graphql
+{
+  vault(id: "0x002f198c46664c28f0685ba86303256e9833344a54c7b4e34483e7805f5b8d4a") {
+    status
+    amount
+    depositor
+    vaultProvider
+    vaultProviderCommissionBps
+    peginTxHash
+    depositorPayoutBtcAddress
+    pendingAt
+    verifiedAt
+    activatedAt
+    expiredAt
+    expirationReason
+  }
+}
+```
+
+A vault moves through `pending` → `signatures_collected` → `verified` →
+`available`, then to one of `redeemed`, `liquidated`, `expired`,
+`depositor_withdrawn` or `invalid`. The matching timestamp field tells you when
+each step happened.
+
+### Check my Aave position and its collateral
+
+```graphql
+{
+  aavePosition(depositorAddress: "0xd51d8dda9f8975fbecacd77a93f37a57053642e1") {
+    totalCollateral
+    proxyContract
+    createdAt
+    updatedAt
+    collaterals(limit: 10) {
+      totalCount
+      items {
+        vaultId
+        amount
+        addedAt
+        removedAt
+        liquidationIndex
+      }
+    }
+  }
+}
+```
+
+A `removedAt` of `null` means the collateral is still pledged.
+
+### Read my activity history
+
+```graphql
+{
+  vaultActivitys(
+    where: { depositor: "0x106d71c740aeebf6e72f06dad4129651dc65d810" }
+    orderBy: "timestamp"
+    orderDirection: "desc"
+    limit: 20
+  ) {
+    totalCount
+    items {
+      type
+      amount
+      vaultId
+      timestamp
+      transactionHash
+    }
+  }
+}
+```
+
+`type` is one of `deposit`, `withdrawal`, `add_collateral`, `remove_collateral`,
+`liquidation`, `borrow`, `repay`, `redeem`, `claim_expired`.
+
+---
+
+## For operators
+
+### Protocol totals
+
+```graphql
+{
+  statss(limit: 1) {
+    items {
+      totalAvailableSats
+      availableVaultCount
+      updatedAt
+    }
+  }
+  protocolStates(limit: 1) {
+    items {
+      activeVaultCoreVersion
+      updatedAt
+    }
+  }
+}
+```
+
+### Registered vault providers
+
+```graphql
+{
+  vaultProviders(orderBy: "registeredAt", orderDirection: "asc", limit: 50) {
+    totalCount
+    items {
+      id
+      name
+      commissionBps
+      metadataStatus
+      metadataRejectionReason
+      registeredAt
+    }
+  }
+}
+```
+
+### The security participant set
+
+Vault keepers are per-application. Universal challengers are system-wide.
+
+```graphql
+{
+  vaultKeepers(limit: 50) {
+    totalCount
+    items {
+      id
+    }
+  }
+  universalChallengers(limit: 50) {
+    totalCount
+    items {
+      id
+    }
+  }
+  universalChallengerVersions(orderBy: "id", orderDirection: "desc", limit: 5) {
+    items {
+      id
+    }
+  }
+}
+```
+
+### Vault count by status
+
+The endpoint allows at most **15 aliases** per operation, so keep status
+breakdowns to a handful of aliases per request.
+
+```graphql
+{
+  pending: vaults(where: { status: pending }, limit: 1) {
+    totalCount
+  }
+  verified: vaults(where: { status: verified }, limit: 1) {
+    totalCount
+  }
+  available: vaults(where: { status: available }, limit: 1) {
+    totalCount
+  }
+  redeemed: vaults(where: { status: redeemed }, limit: 1) {
+    totalCount
+  }
+  expired: vaults(where: { status: expired }, limit: 1) {
+    totalCount
+  }
+  liquidated: vaults(where: { status: liquidated }, limit: 1) {
+    totalCount
+  }
+}
+```
+
+### Fee escrow state
+
+```graphql
+{
+  escrowed: vaultFeeEscrows(where: { status: escrowed }, limit: 1) {
+    totalCount
+  }
+  distributed: vaultFeeEscrows(where: { status: distributed }, limit: 1) {
+    totalCount
+  }
+  refunded: vaultFeeEscrows(where: { status: refunded }, limit: 1) {
+    totalCount
+  }
+  forfeited: vaultFeeEscrows(where: { status: forfeited }, limit: 1) {
+    totalCount
+  }
+}
+```
+
+### Indexer sync status
+
+`_meta` reports the last block the indexer processed. Compare it against a chain
+head to measure lag.
+
+```graphql
+{
+  _meta {
+    status
+  }
+}
+```
+
+---
+
+## For builders
+
+### Paginate past the 1000-row cap
+
+`limit` is capped at 1000. Page with `offset`, and stop when you have collected
+`totalCount` rows.
+
+```graphql
+{
+  vaults(orderBy: "pendingAt", orderDirection: "asc", limit: 1000, offset: 0) {
+    totalCount
+    items {
+      id
+      status
+    }
+  }
+}
+```
+
+Ordering matters. Without a stable `orderBy`, rows can repeat or vanish between
+pages.
+
+### Filter operators
+
+Every scalar field gets a family of suffixed filters — `_not`, `_in`,
+`_not_in`, `_gt`, `_gte`, `_lt`, `_lte`, and for strings `_contains`,
+`_starts_with`, `_ends_with`. Combine them with `AND` and `OR`.
+
+```graphql
+{
+  vaults(
+    where: {
+      AND: [
+        { status: available }
+        { amount_gte: "1000000" }
+        { inUse: false }
+      ]
+    }
+    orderBy: "amount"
+    orderDirection: "desc"
+    limit: 5
+  ) {
+    totalCount
+    items {
+      id
+      amount
+      inUse
+    }
+  }
+}
+```
+
+`BigInt` comparisons take strings, not numbers.
+
+### Follow a relation
+
+Some entities expose the related record directly, which avoids a second round
+trip.
+
+```graphql
+{
+  vaultFeeEscrows(limit: 3, orderBy: "escrowedAt", orderDirection: "desc") {
+    items {
+      vaultId
+      totalAmount
+      status
+      numUniversalChallengers
+      numAppVaultKeepers
+      vault {
+        status
+        depositor
+      }
+    }
+  }
+}
+```
+
+Keep an eye on nesting. The endpoint rejects any operation deeper than **10**
+levels.
+
+### Introspect within the depth cap
+
+The standard introspection query that GraphiQL and most tooling sends is depth
+21, and this endpoint rejects it. This shorter query lists every type and is
+depth 4.
+
+```graphql
+{
+  __schema {
+    types {
+      kind
+      name
+    }
+  }
+}
+```
+
+To read one type's fields without tripping the cap:
+
+```graphql
+{
+  __type(name: "vault") {
+    name
+    fields {
+      name
+      type {
+        kind
+        name
+        ofType {
+          kind
+          name
+        }
+      }
+    }
+  }
+}
+```
+
+Four such queries reconstruct the entire schema. The docs site ships the result
+already assembled at
+[`/schema/vault-indexer.graphql`](/schema/vault-indexer.graphql), so most builders
+never need to introspect at all.

--- a/docs/trustless-bitcoin-vault/apis/schema-reference.mdx
+++ b/docs/trustless-bitcoin-vault/apis/schema-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: Schema Reference
 sidebar_label: Schema Reference
-sidebar_position: 2
+sidebar_position: 3
 description: Every entity, field and type exposed by the Babylon vault indexer GraphQL API.
 ---
 

--- a/docs/trustless-bitcoin-vault/apis/schema-reference.mdx
+++ b/docs/trustless-bitcoin-vault/apis/schema-reference.mdx
@@ -88,7 +88,16 @@ Query with `vault(…)` or `vaults(…)`.
 
 ### `vaultActivity`
 
-Append-only event log of every action taken against a vault.
+Append-only event log. It records six of the nine `vaultActivityType` values —
+`deposit`, `borrow`, `repay`, `redeem`, `liquidation` and `claim_expired`. It is
+not a complete history of everything that happens to a vault. See
+[Known data gaps](./limits-and-gotchas.mdx).
+
+`vaultId` is `null` on `borrow` and `repay` rows. Those events are scoped to an
+Aave position rather than to one vault, and they instead carry a non-null
+`debtReserveId`. Resolve that against `aaveReserve` to get the debt asset's
+symbol and decimals — `amount` on those rows is denominated in the debt asset,
+not in satoshis.
 
 Query with `vaultActivity(…)` or `vaultActivitys(…)`.
 

--- a/docs/trustless-bitcoin-vault/apis/schema-reference.mdx
+++ b/docs/trustless-bitcoin-vault/apis/schema-reference.mdx
@@ -435,6 +435,6 @@ Query with `aaveConfig(…)` or `aaveConfigs(…)`.
 
 ## Full SDL
 
-The complete schema is committed at [`/schema/vault-indexer.graphql`](/schema/vault-indexer.graphql).
+The complete schema is committed at [`/schema/vault-indexer.graphql`](pathname:///schema/vault-indexer.graphql).
 
 Introspection is available but depth-capped — see [Limits and gotchas](./limits-and-gotchas.mdx) for the four short queries that reconstruct it.

--- a/docs/trustless-bitcoin-vault/apis/schema-reference.mdx
+++ b/docs/trustless-bitcoin-vault/apis/schema-reference.mdx
@@ -1,0 +1,440 @@
+---
+title: Schema Reference
+sidebar_label: Schema Reference
+sidebar_position: 2
+description: Every entity, field and type exposed by the Babylon vault indexer GraphQL API.
+---
+
+{/*
+  GENERATED FILE — DO NOT EDIT BY HAND.
+  Regenerate with: node scripts/gen-vault-indexer-docs.mjs
+  Source of truth: static/schema/vault-indexer.graphql
+*/}
+
+# Schema Reference
+
+Every entity exposed by the vault indexer, generated from the deployed schema.
+
+Each entity has two resolvers:
+
+- **Singular** — `vault(id: "0x…")` returns one record or `null`
+- **Plural** — `vaults(where:, orderBy:, orderDirection:, limit:, offset:)` returns a page
+
+A page always carries `items`, `totalCount` and `pageInfo`. `limit` caps at
+1000; see [Limits and gotchas](./limits-and-gotchas.mdx) before writing a client.
+
+:::note Types are lower-case
+Ponder generates this API from the indexer's table definitions, so type names
+match the table names and are lower-case (`vault`, not `Vault`). The plural of
+`stats` is `statss` for the same reason — the generator appends an `s`.
+:::
+
+
+## Core vault
+
+The vault lifecycle and the actors that secure it. These entities exist regardless of which DeFi application a vault is used with.
+
+
+### `vault`
+
+A single vault instance and its full lifecycle state.
+
+Query with `vault(…)` or `vaults(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `id` | `String!` | yes |
+| `peginTxHash` | `String!` | yes |
+| `depositor` | `String!` | yes |
+| `depositorBtcPubKey` | `String!` | yes |
+| `vaultProvider` | `String!` | yes |
+| `vaultProviderCommissionBps` | `Int!` | yes |
+| `amount` | `BigInt!` | yes |
+| `applicationEntryPoint` | `String!` | yes |
+| `status` | `vaultStatus` | no |
+| `inUse` | `Boolean!` | yes |
+| `ackCount` | `Int!` | yes |
+| `depositorSignedPeginTx` | `String!` | yes |
+| `unsignedPrePeginTx` | `String!` | yes |
+| `appVaultKeepersVersion` | `Int!` | yes |
+| `universalChallengersVersion` | `Int!` | yes |
+| `offchainParamsVersion` | `Int!` | yes |
+| `proverCircuitVersion` | `Int!` | yes |
+| `vaultCoreVersion` | `Int!` | yes |
+| `referralCode` | `Int!` | yes |
+| `depositorPayoutBtcAddress` | `String!` | yes |
+| `btcPopSignature` | `String` | no |
+| `depositorWotsPkHash` | `String` | no |
+| `peginSigsPostedAt` | `BigInt` | no |
+| `prePeginTxHash` | `String` | no |
+| `htlcVout` | `Int!` | yes |
+| `hashlock` | `String!` | yes |
+| `secret` | `String` | no |
+| `currentOwner` | `String` | no |
+| `pendingAt` | `BigInt!` | yes |
+| `verifiedAt` | `BigInt` | no |
+| `activatedAt` | `BigInt` | no |
+| `expiredAt` | `BigInt` | no |
+| `expirationReason` | `String` | no |
+| `claimExpiredUntil` | `BigInt` | no |
+| `expiredClaimedAt` | `BigInt` | no |
+| `blockNumber` | `BigInt!` | yes |
+| `transactionHash` | `String!` | yes |
+| `application` | `application` | no |
+
+
+`vaultStatus` values: `pending` · `signatures_collected` · `verified` · `available` · `redeemed` · `liquidated` · `expired` · `invalid` · `depositor_withdrawn`
+
+
+### `vaultActivity`
+
+Append-only event log of every action taken against a vault.
+
+Query with `vaultActivity(…)` or `vaultActivitys(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `id` | `String!` | yes |
+| `vaultId` | `String` | no |
+| `depositor` | `String!` | yes |
+| `type` | `vaultActivityType!` | yes |
+| `amount` | `BigInt!` | yes |
+| `debtReserveId` | `BigInt` | no |
+| `timestamp` | `BigInt!` | yes |
+| `blockNumber` | `BigInt!` | yes |
+| `transactionHash` | `String!` | yes |
+
+
+`vaultActivityType` values: `deposit` · `withdrawal` · `add_collateral` · `remove_collateral` · `liquidation` · `borrow` · `repay` · `redeem` · `claim_expired`
+
+
+### `vaultProvider`
+
+A registered entity that provides vault services.
+
+Query with `vaultProvider(…)` or `vaultProviders(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `id` | `String!` | yes |
+| `btcPubKey` | `String!` | yes |
+| `applicationEntryPoint` | `String!` | yes |
+| `commissionBps` | `Int!` | yes |
+| `name` | `String` | no |
+| `rpcUrl` | `String` | no |
+| `grpcUrl` | `String` | no |
+| `daemonGrpcUrl` | `String` | no |
+| `metadataStatus` | `String` | no |
+| `metadataRejectionReason` | `String` | no |
+| `registeredAt` | `BigInt!` | yes |
+| `blockNumber` | `BigInt!` | yes |
+| `transactionHash` | `String!` | yes |
+
+
+### `vaultProviderStats`
+
+Aggregated counters per vault provider.
+
+Query with `vaultProviderStats(…)` or `vaultProviderStatss(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `id` | `String!` | yes |
+| `activeVaultCount` | `Int!` | yes |
+| `totalActiveSats` | `BigInt!` | yes |
+| `updatedAt` | `BigInt!` | yes |
+| `provider` | `vaultProvider` | no |
+
+
+### `vaultKeeper`
+
+A per-application participant in the vault security model.
+
+Query with `vaultKeeper(…)` or `vaultKeepers(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `id` | `String!` | yes |
+| `btcPubKey` | `String!` | yes |
+| `firstSeenAt` | `BigInt!` | yes |
+| `blockNumber` | `BigInt!` | yes |
+
+
+### `vaultKeeperApplication`
+
+Join between a vault keeper and an application.
+
+Query with `vaultKeeperApplication(…)` or `vaultKeeperApplications(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `id` | `String!` | yes |
+| `vaultKeeper` | `String!` | yes |
+| `applicationEntryPoint` | `String!` | yes |
+| `version` | `Int!` | yes |
+| `registeredAt` | `BigInt!` | yes |
+| `blockNumber` | `BigInt!` | yes |
+| `vaultKeeperInfo` | `vaultKeeper` | no |
+
+
+### `universalChallenger`
+
+A system-wide participant able to challenge invalid claims.
+
+Query with `universalChallenger(…)` or `universalChallengers(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `id` | `String!` | yes |
+| `btcPubKey` | `String!` | yes |
+| `firstSeenAt` | `BigInt!` | yes |
+| `blockNumber` | `BigInt!` | yes |
+
+
+### `universalChallengerVersion`
+
+Versioned challenger set.
+
+Query with `universalChallengerVersion(…)` or `universalChallengerVersions(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `id` | `String!` | yes |
+| `challengerId` | `String!` | yes |
+| `version` | `Int!` | yes |
+| `blockNumber` | `BigInt!` | yes |
+| `challengerInfo` | `universalChallenger` | no |
+
+
+### `feeConfig`
+
+Fee configuration. Currently empty on testnet — see Limits and gotchas.
+
+Query with `feeConfig(…)` or `feeConfigs(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `id` | `String!` | yes |
+| `vpFeeRate` | `BigInt!` | yes |
+| `ucFeeRate` | `BigInt!` | yes |
+| `avkFeeRate` | `BigInt!` | yes |
+| `protocolPegInFeeRate` | `BigInt!` | yes |
+| `vpRegistrationFee` | `BigInt!` | yes |
+| `updatedAt` | `BigInt!` | yes |
+| `blockNumber` | `BigInt!` | yes |
+
+
+### `vaultFeeEscrow`
+
+Escrowed fees for one vault. One row per vault.
+
+Query with `vaultFeeEscrow(…)` or `vaultFeeEscrows(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `vaultId` | `String!` | yes |
+| `totalAmount` | `BigInt!` | yes |
+| `vaultProvider` | `String!` | yes |
+| `numUniversalChallengers` | `Int!` | yes |
+| `numAppVaultKeepers` | `Int!` | yes |
+| `status` | `feeEscrowStatus!` | yes |
+| `escrowedAt` | `BigInt!` | yes |
+| `distributedAt` | `BigInt` | no |
+| `refundedAt` | `BigInt` | no |
+| `forfeitedAt` | `BigInt` | no |
+| `blockNumber` | `BigInt!` | yes |
+| `transactionHash` | `String!` | yes |
+| `vault` | `vault` | no |
+
+
+`feeEscrowStatus` values: `escrowed` · `distributed` · `refunded` · `forfeited`
+
+
+### `application`
+
+A DeFi protocol integrated with the vault system.
+
+Query with `application(…)` or `applications(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `id` | `String!` | yes |
+| `name` | `String` | no |
+| `latestVKVersion` | `Int` | no |
+| `totalCapBTC` | `BigInt` | no |
+| `perAddressCapBTC` | `BigInt` | no |
+| `status` | `applicationStatus!` | yes |
+| `registeredAt` | `BigInt!` | yes |
+| `blockNumber` | `BigInt!` | yes |
+| `transactionHash` | `String!` | yes |
+
+
+`applicationStatus` values: `none` · `active` · `paused`
+
+
+### `token`
+
+A token known to the indexer.
+
+Query with `token(…)` or `tokens(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `address` | `String!` | yes |
+| `symbol` | `String!` | yes |
+| `name` | `String!` | yes |
+| `decimals` | `Int!` | yes |
+
+
+### `stats`
+
+Protocol-wide totals. Singleton.
+
+Query with `stats(…)` or `statss(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `id` | `String!` | yes |
+| `totalAvailableSats` | `BigInt!` | yes |
+| `availableVaultCount` | `Int!` | yes |
+| `updatedAt` | `BigInt!` | yes |
+
+
+### `protocolState`
+
+Protocol-level singleton state, such as the active vault-core version.
+
+Query with `protocolState(…)` or `protocolStates(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `id` | `String!` | yes |
+| `activeVaultCoreVersion` | `Int!` | yes |
+| `updatedAt` | `BigInt!` | yes |
+| `blockNumber` | `BigInt!` | yes |
+| `transactionHash` | `String!` | yes |
+
+
+## Aave application
+
+State for the Aave v4 integration — the first application built on TBV. A vault used as Aave collateral appears in both domains.
+
+
+### `aavePosition`
+
+A depositor position, keyed by depositor address.
+
+Query with `aavePosition(…)` or `aavePositions(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `depositorAddress` | `String!` | yes |
+| `proxyContract` | `String!` | yes |
+| `totalCollateral` | `BigInt!` | yes |
+| `createdAt` | `BigInt!` | yes |
+| `updatedAt` | `BigInt!` | yes |
+| `blockNumber` | `BigInt!` | yes |
+| `transactionHash` | `String!` | yes |
+| `collaterals(…)` | `aavePositionCollateralPage` | no |
+
+
+### `aavePositionCollateral`
+
+One vault pledged as collateral against a position.
+
+Query with `aavePositionCollateral(…)` or `aavePositionCollaterals(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `depositorAddress` | `String!` | yes |
+| `vaultId` | `String!` | yes |
+| `amount` | `BigInt!` | yes |
+| `addedAt` | `BigInt!` | yes |
+| `removedAt` | `BigInt` | no |
+| `liquidationIndex` | `Int!` | yes |
+| `blockNumber` | `BigInt!` | yes |
+| `transactionHash` | `String!` | yes |
+| `position` | `aavePosition` | no |
+| `vault` | `vault` | no |
+
+
+### `aaveVaultStatus`
+
+Per-vault usage status within Aave.
+
+Query with `aaveVaultStatus(…)` or `aaveVaultStatuss(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `vaultId` | `String!` | yes |
+| `applicationEntryPoint` | `String!` | yes |
+| `status` | `aaveVaultUsageStatus!` | yes |
+| `metadata` | `JSON` | no |
+| `updatedAt` | `BigInt!` | yes |
+| `vault` | `vault` | no |
+
+
+`aaveVaultUsageStatus` values: `collateralized` · `llp_owned` · `redeemed`
+
+
+### `aaveUserProxy`
+
+The proxy contract deployed for a user.
+
+Query with `aaveUserProxy(…)` or `aaveUserProxys(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `user` | `String!` | yes |
+| `proxy` | `String!` | yes |
+| `createdAt` | `BigInt!` | yes |
+| `blockNumber` | `BigInt!` | yes |
+| `transactionHash` | `String!` | yes |
+
+
+### `aaveReserve`
+
+An Aave reserve and its parameters.
+
+Query with `aaveReserve(…)` or `aaveReserves(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `id` | `BigInt!` | yes |
+| `underlying` | `String!` | yes |
+| `hub` | `String!` | yes |
+| `assetId` | `Int!` | yes |
+| `decimals` | `Int!` | yes |
+| `dynamicConfigKey` | `BigInt!` | yes |
+| `paused` | `Boolean!` | yes |
+| `frozen` | `Boolean!` | yes |
+| `borrowable` | `Boolean!` | yes |
+| `collateralRisk` | `Int!` | yes |
+| `collateralFactor` | `Int!` | yes |
+| `createdAt` | `BigInt!` | yes |
+| `updatedAt` | `BigInt!` | yes |
+| `blockNumber` | `BigInt!` | yes |
+| `underlyingToken` | `token` | no |
+
+
+### `aaveConfig`
+
+Aave integration configuration. Singleton.
+
+Query with `aaveConfig(…)` or `aaveConfigs(…)`.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `id` | `Int!` | yes |
+| `adapterAddress` | `String!` | yes |
+| `vaultBtcAddress` | `String!` | yes |
+| `btcVaultRegistryAddress` | `String!` | yes |
+| `btcVaultCoreSpokeAddress` | `String!` | yes |
+| `vaultBtcReserveId` | `BigInt!` | yes |
+
+
+## Full SDL
+
+The complete schema is committed at [`/schema/vault-indexer.graphql`](/schema/vault-indexer.graphql).
+
+Introspection is available but depth-capped — see [Limits and gotchas](./limits-and-gotchas.mdx) for the four short queries that reconstruct it.

--- a/docs/trustless-bitcoin-vault/apis/use-cases.mdx
+++ b/docs/trustless-bitcoin-vault/apis/use-cases.mdx
@@ -1,0 +1,465 @@
+---
+title: Use Cases
+sidebar_label: Use Cases
+sidebar_position: 2
+description: End-to-end workflows you can build on the Babylon vault indexer — portfolio views, peg-in tracking, operator dashboards, risk watchers and data sync.
+---
+
+# Use Cases
+
+The [Query Cookbook](./query-cookbook.mdx) answers single questions. This page
+chains those answers into complete workflows, so you can see what a finished
+integration looks like before you write one.
+
+Every query below runs against live testnet data and returns rows. Copy any of
+them into the explorer or send them with `curl`.
+
+:::warning Set a User-Agent
+The endpoint rejects default library user-agents with a bare **403**. Set your
+own on every request. See [Limits and gotchas](./limits-and-gotchas.mdx).
+:::
+
+## Pick your workflow
+
+| You are building | Workflow | Core entities |
+| --- | --- | --- |
+| A wallet or portfolio screen | [Depositor portfolio](#1-depositor-portfolio) | `vault`, `aavePosition`, `vaultActivity` |
+| Peg-in status or onboarding UX | [Track a peg-in](#2-track-a-peg-in-to-completion) | `vault` |
+| An operator or protocol dashboard | [Protocol health](#3-protocol-health-dashboard) | `stats`, `vaultProviderStats`, `_meta` |
+| Monitoring or alerting | [Risk watcher](#4-expiry-and-liquidation-watcher) | `vault`, `aaveVaultStatus` |
+| Analytics, a data warehouse, a bot | [Mirror the dataset](#5-mirror-the-dataset) | everything |
+
+---
+
+## 1. Depositor portfolio
+
+**Goal:** given one address, show what they hold, what is pledged, what they
+owe, and what they have done.
+
+### Step 1 — their vaults
+
+`status` tells you where each vault is. `inUse` tells you whether it is pledged
+to an application.
+
+```graphql
+{
+  vaults(
+    where: { depositor: "0xd51d8dda9f8975fbecacd77a93f37a57053642e1" }
+    orderBy: "pendingAt"
+    orderDirection: "desc"
+    limit: 3
+  ) {
+    totalCount
+    items {
+      id
+      status
+      amount
+      inUse
+      activatedAt
+    }
+  }
+}
+```
+
+### Step 2 — what is currently pledged
+
+`aavePosition` is keyed by `depositorAddress`, not by `id`. Filter the nested
+collaterals on `removedAt: null` to get only what is still pledged — the table
+keeps released rows for history.
+
+```graphql
+{
+  aavePosition(depositorAddress: "0xd51d8dda9f8975fbecacd77a93f37a57053642e1") {
+    totalCollateral
+    proxyContract
+    collaterals(where: { removedAt: null }, limit: 3) {
+      totalCount
+      items {
+        vaultId
+        amount
+        addedAt
+      }
+    }
+  }
+}
+```
+
+`totalCollateral` equals the sum of `amount` across those live rows, in
+satoshis. Use it as a checksum.
+
+### Step 3 — their ledger
+
+```graphql
+{
+  vaultActivitys(
+    where: { depositor: "0xd51d8dda9f8975fbecacd77a93f37a57053642e1" }
+    orderBy: "timestamp"
+    orderDirection: "desc"
+    limit: 3
+  ) {
+    items {
+      type
+      amount
+      vaultId
+      debtReserveId
+      timestamp
+    }
+  }
+}
+```
+
+### Step 4 — make the numbers mean something
+
+Fetch the reserve table once and cache it. Without it you cannot format a loan
+amount correctly.
+
+```graphql
+{
+  aaveReserves {
+    items {
+      id
+      borrowable
+      underlyingToken {
+        symbol
+        decimals
+      }
+    }
+  }
+}
+```
+
+:::danger Amounts are not all satoshis
+On `borrow` and `repay` rows, `amount` is denominated in the **debt asset**, and
+`vaultId` is `null` because the event belongs to the position rather than to one
+vault. Join `debtReserveId` to the table above for the symbol and decimals.
+
+A repayment of `294141396` with `debtReserveId: "1"` is **294.14 USDT**, not
+2.94 BTC. Format it as satoshis and you are wrong by orders of magnitude.
+:::
+
+---
+
+## 2. Track a peg-in to completion
+
+**Goal:** tell a depositor where their peg-in is, and whether it is stuck.
+
+### Step 1 — read the vault
+
+Poll a single vault by `id`. Read `status` first; the timestamps only tell you
+*when* each completed step happened.
+
+```graphql
+{
+  vault(id: "0x822ecce7d8dac56426935b3c344778cb214eec1a368100a190ea2b31d3c56d3f") {
+    status
+    amount
+    pendingAt
+    peginSigsPostedAt
+    verifiedAt
+    activatedAt
+    expiredAt
+    expirationReason
+    ackCount
+    inUse
+  }
+}
+```
+
+A healthy completed peg-in shows all four timestamps filled, `ackCount: 6` and
+`status: available`. Map the state to the field that dates it:
+
+| Status | Timestamp to show |
+| --- | --- |
+| `pending` | `pendingAt` |
+| `signatures_collected` | `peginSigsPostedAt` |
+| `verified` | `verifiedAt` |
+| `available` | `activatedAt` |
+| `expired` | `expiredAt`, plus `expirationReason` |
+
+### Step 2 — find everything still in flight
+
+```graphql
+{
+  vaults(
+    where: { status_in: [pending, signatures_collected, verified] }
+    orderBy: "pendingAt"
+    orderDirection: "desc"
+    limit: 3
+  ) {
+    totalCount
+    items {
+      id
+      status
+      ackCount
+      pendingAt
+    }
+  }
+}
+```
+
+**`ackCount` is your health signal.** It climbs to 6 once the full security set
+has acknowledged. A vault sitting at `signatures_collected` with `ackCount: 0`
+is stalling, and the usual outcome is expiry with
+`expirationReason: "ack_timeout"`. Surface that before the user asks.
+
+:::info Expect expiry to be common
+On testnet the majority of peg-ins expire rather than activate. Design the
+screen around that reality instead of treating expiry as an edge case.
+:::
+
+---
+
+## 3. Protocol health dashboard
+
+**Goal:** one screen showing size, throughput, who is carrying the load, and
+whether the data is fresh.
+
+### Step 1 — headline totals
+
+```graphql
+{
+  statss(limit: 1) {
+    items {
+      totalAvailableSats
+      availableVaultCount
+    }
+  }
+}
+```
+
+### Step 2 — the funnel
+
+Aliases let you count several statuses in one request. You have a budget of 15
+per operation, which is enough for all nine statuses at once.
+
+```graphql
+{
+  pending: vaults(where: { status: pending }) { totalCount }
+  available: vaults(where: { status: available }) { totalCount }
+  expired: vaults(where: { status: expired }) { totalCount }
+  liquidated: vaults(where: { status: liquidated }) { totalCount }
+}
+```
+
+The ratio of `expired` to `available` is the number worth watching. It is the
+real measure of peg-in completion, and it is not visible from headline TVL.
+
+### Step 3 — provider distribution
+
+```graphql
+{
+  vaultProviderStatss(
+    orderBy: "totalActiveSats"
+    orderDirection: "desc"
+    limit: 4
+  ) {
+    items {
+      activeVaultCount
+      totalActiveSats
+      provider {
+        name
+        commissionBps
+      }
+    }
+  }
+}
+```
+
+`commissionBps` is in basis points, so `100` is 1%.
+
+### Step 4 — stamp it with freshness
+
+```graphql
+{
+  _meta {
+    status
+  }
+}
+```
+
+This returns a JSON scalar keyed by chain name, carrying the last indexed block
+and its timestamp. Compare that block against a Sepolia node before you present
+any figure as current. A lag of roughly a minute is normal.
+
+---
+
+## 4. Expiry and liquidation watcher
+
+**Goal:** alerting. Catch collateral at risk and record what actually happened.
+
+### Step 1 — collateral in use
+
+```graphql
+{
+  vaults(
+    where: { AND: [{ status: available }, { inUse: true }] }
+    orderBy: "amount"
+    orderDirection: "desc"
+    limit: 3
+  ) {
+    totalCount
+    items {
+      id
+      amount
+      depositor
+    }
+  }
+}
+```
+
+### Step 2 — confirm how a vault is being used
+
+```graphql
+{
+  aaveVaultStatus(
+    vaultId: "0x822ecce7d8dac56426935b3c344778cb214eec1a368100a190ea2b31d3c56d3f"
+  ) {
+    status
+    vaultId
+  }
+}
+```
+
+`status` is `collateralized`, `llp_owned` or `redeemed`.
+
+### Step 3 — the claim window on expired vaults
+
+```graphql
+{
+  vaults(
+    where: { status: expired }
+    orderBy: "expiredAt"
+    orderDirection: "desc"
+    limit: 3
+  ) {
+    items {
+      id
+      expiredAt
+      expirationReason
+      claimExpiredUntil
+    }
+  }
+}
+```
+
+:::danger claimExpiredUntil is a block number
+Despite the name and its position among timestamp fields, `claimExpiredUntil` is
+a **block height** — the expiry block plus a grace period. Compare it against
+the block number in `_meta`, never against a clock. Read as seconds it resolves
+to 1970.
+:::
+
+### Step 4 — the liquidation feed
+
+```graphql
+{
+  vaultActivitys(
+    where: { type: liquidation }
+    orderBy: "timestamp"
+    orderDirection: "desc"
+    limit: 3
+  ) {
+    totalCount
+    items {
+      vaultId
+      amount
+      timestamp
+      transactionHash
+    }
+  }
+}
+```
+
+Liquidations do carry a `vaultId`, so this feed joins straight back to `vault`.
+
+---
+
+## 5. Mirror the dataset
+
+**Goal:** pull everything into your own store, then keep it current.
+
+### Step 1 — generate a typed client
+
+Introspection is capped at depth 10, so the standard introspection query fails.
+Point your codegen at the committed SDL instead —
+[`/schema/vault-indexer.graphql`](pathname:///schema/vault-indexer.graphql):
+
+```bash
+curl -sO https://docs.babylonlabs.io/schema/vault-indexer.graphql
+```
+
+The SDL is regenerated from the deployed endpoint, so it describes what is
+actually in production rather than what is on the indexer's main branch.
+
+### Step 2 — sweep each table
+
+Always pass an explicit `limit` and a stable `orderBy`. Stop when the rows you
+have collected reach `totalCount`.
+
+```graphql
+{
+  vaults(orderBy: "pendingAt", orderDirection: "asc", limit: 2, offset: 0) {
+    totalCount
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    items {
+      id
+      status
+    }
+  }
+}
+```
+
+Raise `limit` to 1000 for a real sweep and advance `offset` by the same amount.
+You can page by cursor instead — feed `endCursor` back as `after`. Pick one
+style, because `pageInfo` cursors come back `null` as soon as you pass `offset`.
+
+:::danger Omitting limit silently truncates
+With no `limit` you get **50 rows** while `totalCount` still reports the true
+total. A sync that ignores `limit` looks like it succeeded and quietly holds a
+fraction of the data. Always compare what you collected against `totalCount`.
+:::
+
+### Step 3 — stay current
+
+For append-only tables, keep a timestamp watermark and ask only for what is new.
+
+```graphql
+{
+  vaultActivitys(
+    where: { timestamp_gt: "1786000000" }
+    orderBy: "timestamp"
+    orderDirection: "asc"
+    limit: 3
+  ) {
+    totalCount
+    items {
+      id
+      type
+      timestamp
+    }
+  }
+}
+```
+
+Mutable rows such as `vault` change in place, so a timestamp watermark will miss
+edits. Re-read those by `id`, or re-sweep them on a schedule.
+
+Record the block number from `_meta` alongside each sync. It gives you a
+reproducible point to resume from, and it lets you prove how stale a downstream
+figure is.
+
+---
+
+## Before you ship
+
+- Set a `User-Agent`, or every request gets a bare 403.
+- Set `limit` explicitly on every list query.
+- Resolve `debtReserveId` before formatting any loan amount.
+- Treat `claimExpiredUntil` as a block height.
+- Three `vaultActivityType` values are never written. Read
+  [Known data gaps](./limits-and-gotchas.mdx) before you build on
+  `withdrawal`, `add_collateral` or `remove_collateral`.
+- This is testnet. There is no mainnet endpoint yet.

--- a/docs/trustless-bitcoin-vault/apis/vault-indexer-api.mdx
+++ b/docs/trustless-bitcoin-vault/apis/vault-indexer-api.mdx
@@ -1,0 +1,132 @@
+---
+title: Vault Indexer API
+sidebar_label: Vault Indexer API
+sidebar_position: 1
+description: The public GraphQL API for Babylon Trustless Bitcoin Vault testnet — endpoint, explorer, schema and limits.
+---
+
+# Vault Indexer API
+
+The vault indexer is a public, read-only GraphQL API over Babylon Trustless
+Bitcoin Vault state. It indexes events from the vault contracts and serves vault
+lifecycle, provider, security-participant and Aave position data.
+
+No API key. No authentication. Cross-origin requests are permitted.
+
+## Endpoint
+
+| | |
+| --- | --- |
+| **URL** | `https://babylon-vault-indexer-api.testnet.babylonlabs.io/` |
+| **Method** | `POST` with `Content-Type: application/json` |
+| **Alternate path** | `/graphql` — identical behaviour |
+| **Explorer** | Open the URL in a browser |
+| **Network** | Ethereum Sepolia (chain ID `11155111`) |
+| **Auth** | None |
+| **CORS** | Open |
+
+Testnet only. There is no mainnet endpoint yet.
+
+```bash
+curl -s https://babylon-vault-indexer-api.testnet.babylonlabs.io/ \
+  -H 'Content-Type: application/json' \
+  -H 'User-Agent: my-app/1.0' \
+  -d '{"query":"{ statss(limit:1){ items{ totalAvailableSats availableVaultCount } } }"}'
+```
+
+:::warning Three things that will catch you out
+1. Set a **`User-Agent`**. The default one from `requests`, `urllib` or many HTTP
+   clients gets a bare **403** from the edge.
+2. Query depth is capped at **10**, so standard GraphQL tooling **cannot
+   introspect** this endpoint.
+3. `limit` is capped at **1000**. Page with `offset`.
+
+All three are explained in [Limits and gotchas](./limits-and-gotchas.mdx). Read that
+page before you write a client.
+:::
+
+## What the API covers
+
+The schema splits into two domains.
+
+### Core vault
+
+The vault lifecycle and the actors that secure it, independent of any
+application: `vault`, `vaultActivity`, `vaultProvider`, `vaultProviderStats`,
+`vaultKeeper`, `universalChallenger`, `vaultFeeEscrow`, `feeConfig`,
+`application`, `token`, `stats` and `protocolState`.
+
+A vault progresses through:
+
+```
+pending → signatures_collected → verified → available
+                                              ├→ redeemed
+                                              ├→ liquidated
+                                              ├→ expired
+                                              ├→ depositor_withdrawn
+                                              └→ invalid
+```
+
+Each transition has its own timestamp field on the `vault` record, so you can
+reconstruct a full history from a single query.
+
+### Aave application
+
+State for the Aave v4 integration, the first application built on TBV:
+`aavePosition`, `aavePositionCollateral`, `aaveVaultStatus`, `aaveUserProxy`,
+`aaveReserve` and `aaveConfig`.
+
+A vault used as Aave collateral appears in both domains — as a `vault` and as an
+`aavePositionCollateral`.
+
+## Query shape
+
+Every entity has two resolvers.
+
+| Form | Example | Returns |
+| --- | --- | --- |
+| Singular | `vault(id: "0x…")` | One record, or `null` |
+| Plural | `vaults(where:, orderBy:, orderDirection:, limit:, offset:)` | A page |
+
+A page always carries `items`, `totalCount` and `pageInfo`. `totalCount` is the
+number of records matching the filter, not the number returned.
+
+Numeric values typed `BigInt` — amounts, block numbers, timestamps — are returned
+as **strings**, and comparison filters on them take strings too.
+
+## Explorer
+
+Opening the endpoint in a browser serves a GraphiQL playground. You can write and
+run queries there.
+
+:::caution The explorer cannot load the schema
+Because of the depth cap, the explorer's **Docs** panel shows
+`Error fetching schema`, and there is no autocomplete or in-editor validation.
+Queries still execute normally.
+
+Use the [Schema Reference](./schema-reference.mdx) on this site for field names, or
+the committed [SDL](/schema/vault-indexer.graphql).
+:::
+
+## Checking indexer freshness
+
+The indexer trails the chain. `_meta` reports the last processed block.
+
+```graphql
+{
+  _meta {
+    status
+  }
+}
+```
+
+Compare that block number against a Sepolia chain head before treating any
+result as current.
+
+## Where to go next
+
+- **[Schema Reference](./schema-reference.mdx)** — every entity, field and type
+- **[Query Cookbook](./query-cookbook.mdx)** — worked queries for depositors,
+  operators and builders, all executed in CI
+- **[Limits and gotchas](./limits-and-gotchas.mdx)** — depth, pagination, the 403
+  trap, and known data gaps

--- a/docs/trustless-bitcoin-vault/apis/vault-indexer-api.mdx
+++ b/docs/trustless-bitcoin-vault/apis/vault-indexer-api.mdx
@@ -53,8 +53,9 @@ The schema splits into two domains.
 
 The vault lifecycle and the actors that secure it, independent of any
 application: `vault`, `vaultActivity`, `vaultProvider`, `vaultProviderStats`,
-`vaultKeeper`, `universalChallenger`, `vaultFeeEscrow`, `feeConfig`,
-`application`, `token`, `stats` and `protocolState`.
+`vaultKeeper`, `vaultKeeperApplication`, `universalChallenger`,
+`universalChallengerVersion`, `vaultFeeEscrow`, `feeConfig`, `application`,
+`token`, `stats` and `protocolState`.
 
 A vault progresses through:
 
@@ -67,8 +68,18 @@ pending → signatures_collected → verified → available
                                               └→ invalid
 ```
 
-Each transition has its own timestamp field on the `vault` record, so you can
-reconstruct a full history from a single query.
+`status` is the authority on where a vault sits. Timestamps cover only part of
+the path, so do not expect one field per state:
+
+| State | Field that dates it |
+| --- | --- |
+| `pending` | `pendingAt` |
+| `signatures_collected` | `peginSigsPostedAt` |
+| `verified` | `verifiedAt` |
+| `available` | `activatedAt` |
+| `expired` | `expiredAt`, with `expirationReason` |
+| `redeemed`, `liquidated` | none on the vault — read `vaultActivity` |
+| `depositor_withdrawn`, `invalid` | none — `status` is the only signal |
 
 ### Aave application
 
@@ -105,7 +116,7 @@ Because of the depth cap, the explorer's **Docs** panel shows
 Queries still execute normally.
 
 Use the [Schema Reference](./schema-reference.mdx) on this site for field names, or
-the committed [SDL](/schema/vault-indexer.graphql).
+the committed [SDL](pathname:///schema/vault-indexer.graphql).
 :::
 
 ## Checking indexer freshness

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -466,23 +466,11 @@ const config = {
             to: '/guides/overview/bitcoin_staking/',
             className: 'guides-top-header',
           },
-          {
-            label: 'API',
-            items: [
-              {
-                label: 'Staking API',
-                to: '/api/staking-api/babylon-staking-api',
-              },
-              {
-                label: 'Babylon gRPC',
-                to: '/api/babylon-gRPC/babylon-grpc-api-docs',
-              },
-              {
-                label: 'CometBFT',
-                to: '/api/comet-bft/babylon-grpc-api-docs',
-              },
-            ],
-          },
+          // The top-level "API" dropdown was removed: each product section now owns
+          // its own APIs. The Trustless Bitcoin Vault sidebar carries the Vault
+          // Indexer API, and the Bitcoin Staking sidebar carries the Staking API,
+          // Babylon gRPC and CometBFT. No page URLs changed, so no redirects are
+          // needed — only the navigation moved.
           {
             label: 'Support',
             to: 'https://discord.com/invite/babylonglobal',

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "format:docs": "prettier -w docs",
     "typecheck": "tsc",
     "spell-check": "npx cspell docs/**/*.mdx",
+    "verify:vault-indexer-queries": "node scripts/verify-vault-indexer-queries.mjs",
     "genmd": "docusaurus gen-api-docs all"
   },
   "dependencies": {

--- a/scripts/fetch-vault-indexer-schema.mjs
+++ b/scripts/fetch-vault-indexer-schema.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * Introspect the deployed vault indexer and write static/schema/vault-indexer.graphql.
+ *
+ * The endpoint caps query depth at 10 (src/api/index.ts in babylon-vault-indexer),
+ * so the standard getIntrospectionQuery() — depth 21 — is rejected outright. This
+ * script splits introspection into four shallower queries that each stay under the
+ * cap, then reassembles the SDL locally.
+ *
+ * Cloudflare in front of the endpoint 403s default library user-agents with no
+ * GraphQL error body, so a custom UA is mandatory rather than cosmetic.
+ *
+ * Usage:
+ *   node scripts/fetch-vault-indexer-schema.mjs            # write the SDL
+ *   node scripts/fetch-vault-indexer-schema.mjs --check    # exit 1 if it drifted
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const OUT_PATH = resolve(root, 'static/schema/vault-indexer.graphql');
+const ENDPOINT =
+  process.env.VAULT_INDEXER_ENDPOINT ??
+  'https://babylon-vault-indexer-api.testnet.babylonlabs.io/';
+const USER_AGENT = 'babylonlabs-docs-schema-sync/1.0 (+https://docs.babylonlabs.io)';
+
+const TYPE_REF = 'kind name ofType { kind name ofType { kind name ofType { kind name } } }';
+
+// Four depth-safe queries. Each stays at or under depth 7; the cap is 10.
+const QUERIES = {
+  enums: `{ __schema { types { kind name description enumValues(includeDeprecated:true){ name description } } } }`,
+  fields: `{ __schema { types { name fields(includeDeprecated:true){ name description type { ${TYPE_REF} } } } } }`,
+  args: `{ __schema { types { name fields(includeDeprecated:true){ name args { name description defaultValue type { ${TYPE_REF} } } } } } }`,
+  inputs: `{ __schema { types { name inputFields { name description defaultValue type { ${TYPE_REF} } } } } }`,
+};
+
+async function gql(query) {
+  const res = await fetch(ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'User-Agent': USER_AGENT },
+    body: JSON.stringify({ query }),
+  });
+  if (res.status === 403) {
+    throw new Error(
+      `403 from the edge. This is almost always a blocked User-Agent, not an auth or outage problem.`,
+    );
+  }
+  if (!res.ok) throw new Error(`HTTP ${res.status} from ${ENDPOINT}`);
+  const body = await res.json();
+  if (body.errors) throw new Error(`GraphQL error: ${JSON.stringify(body.errors)}`);
+  return body.data.__schema.types;
+}
+
+/** Render a TypeRef (kind/name/ofType chain) back into GraphQL type syntax. */
+function ref(t) {
+  if (!t) return 'Unknown';
+  if (t.kind === 'NON_NULL') return `${ref(t.ofType)}!`;
+  if (t.kind === 'LIST') return `[${ref(t.ofType)}]`;
+  return t.name;
+}
+
+function buildSdl({ enums, fields, args, inputs }) {
+  const byName = new Map();
+  for (const t of enums) byName.set(t.name, { ...t });
+  for (const t of fields) Object.assign(byName.get(t.name), { fields: t.fields });
+  for (const t of inputs) Object.assign(byName.get(t.name), { inputFields: t.inputFields });
+
+  const argMap = new Map();
+  for (const t of args) for (const f of t.fields ?? []) argMap.set(`${t.name}.${f.name}`, f.args);
+
+  const out = [];
+  for (const t of [...byName.values()].sort((a, b) => a.name.localeCompare(b.name))) {
+    if (t.name.startsWith('__')) continue;
+    if (t.description) out.push(`""" ${t.description} """`);
+    if (t.kind === 'SCALAR') {
+      out.push(`scalar ${t.name}`, '');
+      continue;
+    }
+    if (t.kind === 'ENUM') {
+      out.push(`enum ${t.name} {`, ...t.enumValues.map((v) => `  ${v.name}`), '}', '');
+      continue;
+    }
+    const kw = t.kind === 'INPUT_OBJECT' ? 'input' : 'type';
+    const list = t.kind === 'INPUT_OBJECT' ? t.inputFields : t.fields;
+    out.push(`${kw} ${t.name} {`);
+    for (const f of list ?? []) {
+      const a = argMap.get(`${t.name}.${f.name}`) ?? [];
+      const argStr = a.length
+        ? `(${a
+            .map((x) => `${x.name}: ${ref(x.type)}${x.defaultValue != null ? ` = ${x.defaultValue}` : ''}`)
+            .join(', ')})`
+        : '';
+      if (f.description) out.push(`  """ ${f.description} """`);
+      out.push(
+        `  ${f.name}${argStr}: ${ref(f.type)}${f.defaultValue != null ? ` = ${f.defaultValue}` : ''}`,
+      );
+    }
+    out.push('}', '');
+  }
+  return out.join('\n');
+}
+
+/**
+ * Hash the schema's shape, ignoring cosmetic churn. Ponder does not guarantee a
+ * stable field order, so hashing the raw SDL would open an empty PR whenever the
+ * generator reordered output.
+ */
+export function shapeHash(sdl) {
+  const normalised = sdl
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('"""'))
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .sort()
+    .join('\n');
+  return createHash('sha256').update(normalised).digest('hex');
+}
+
+const [enumsT, fieldsT, argsT, inputsT] = await Promise.all([
+  gql(QUERIES.enums),
+  gql(QUERIES.fields),
+  gql(QUERIES.args),
+  gql(QUERIES.inputs),
+]);
+
+const sdl = buildSdl({ enums: enumsT, fields: fieldsT, args: argsT, inputs: inputsT });
+
+if (process.argv.includes('--check')) {
+  let current = '';
+  try {
+    current = readFileSync(OUT_PATH, 'utf8');
+  } catch {
+    console.log('changed=true');
+    console.error('No committed SDL found.');
+    process.exit(1);
+  }
+  const same = shapeHash(current) === shapeHash(sdl);
+  console.log(`changed=${!same}`);
+  console.error(same ? 'Schema unchanged.' : 'Schema CHANGED — regeneration needed.');
+  process.exit(same ? 0 : 1);
+}
+
+writeFileSync(OUT_PATH, sdl);
+const typeCount = (sdl.match(/^(type|input|enum|scalar) /gm) ?? []).length;
+console.log(`Wrote ${OUT_PATH}\n  types: ${typeCount}\n  shape: ${shapeHash(sdl).slice(0, 16)}`);

--- a/scripts/fetch-vault-indexer-schema.mjs
+++ b/scripts/fetch-vault-indexer-schema.mjs
@@ -107,16 +107,45 @@ function buildSdl({ enums, fields, args, inputs }) {
  * Hash the schema's shape, ignoring cosmetic churn. Ponder does not guarantee a
  * stable field order, so hashing the raw SDL would open an empty PR whenever the
  * generator reordered output.
+ *
+ * Sort WITHIN each block, never across the whole file. A global sort discards
+ * which type each field belongs to, so moving a field from one type to another
+ * produces the identical sorted line multiset and the identical hash. That is a
+ * real schema change the drift check would report as "unchanged" — and this hash
+ * is the workflow's only trigger, so the regeneration would simply never run.
  */
 export function shapeHash(sdl) {
-  const normalised = sdl
-    .split('\n')
-    .filter((l) => !l.trim().startsWith('"""'))
-    .map((l) => l.trim())
-    .filter(Boolean)
-    .sort()
-    .join('\n');
-  return createHash('sha256').update(normalised).digest('hex');
+  const blocks = [];
+  let current = null;
+
+  for (const raw of sdl.split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('"""')) continue;
+
+    if (current) {
+      if (line === '}') {
+        current.members.sort();
+        blocks.push(`${current.header}\n${current.members.join('\n')}\n}`);
+        current = null;
+      } else {
+        current.members.push(line);
+      }
+      continue;
+    }
+
+    if (line.endsWith('{')) current = { header: line, members: [] };
+    // A block-less declaration, e.g. `scalar BigInt`.
+    else blocks.push(line);
+  }
+
+  // An unterminated block still has to contribute, or truncated output would
+  // silently hash the same as the valid schema it was truncated from.
+  if (current) {
+    current.members.sort();
+    blocks.push(`${current.header}\n${current.members.join('\n')}`);
+  }
+
+  return createHash('sha256').update(blocks.sort().join('\n')).digest('hex');
 }
 
 const [enumsT, fieldsT, argsT, inputsT] = await Promise.all([

--- a/scripts/gen-vault-indexer-docs.mjs
+++ b/scripts/gen-vault-indexer-docs.mjs
@@ -92,7 +92,15 @@ const sdl = readFileSync(SDL_PATH, 'utf8');
 const types = parseTypes(sdl);
 const enums = parseEnums(sdl);
 
-const esc = (s) => s.replace(/\|/g, '\\|').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+// Escape for an MDX table cell. The backslash must go first: it is the escape
+// character, so escaping `|` before `\` turns the input `a\|b` into `a\\|b`,
+// which Markdown reads as a literal backslash followed by a live cell divider.
+const esc = (s) =>
+  s
+    .replace(/\\/g, '\\\\')
+    .replace(/\|/g, '\\|')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 const required = (t) => (t.endsWith('!') ? 'yes' : 'no');
 const bare = (t) => t.replace(/[![\]]/g, '');
 

--- a/scripts/gen-vault-indexer-docs.mjs
+++ b/scripts/gen-vault-indexer-docs.mjs
@@ -174,8 +174,51 @@ out.push(
   `Introspection is available but depth-capped — see [Limits and gotchas](./limits-and-gotchas.mdx) for the four short queries that reconstruct it.\n`,
 );
 
+// The SDL is parsed with regexes, not a GraphQL parser. That is fine for
+// Ponder's mechanical output, but a regex that stops matching does not throw —
+// it silently yields fewer fields, and a schema reference that quietly loses a
+// field is indistinguishable from a correct one to a reader. Count the field
+// lines in the raw SDL and compare. This turns a silent loss into a loud stop.
+const parsedFields = [...types.values()].reduce((n, f) => n + f.length, 0);
+
+/**
+ * Count field lines inside `type` blocks with a line scanner rather than the
+ * parser's own regex.
+ *
+ * Using the same pattern for both sides would make the check self-consistent and
+ * therefore useless: a type the parser skips would be skipped by the counter
+ * too, and the totals would agree while a whole type was missing. This scanner
+ * only needs a line to START with `type `, so `type Vault implements Node {`
+ * still contributes — which is precisely the case that must be caught.
+ */
+function countTypeFieldLines(text) {
+  let inType = false;
+  let n = 0;
+  for (const raw of text.split('\n')) {
+    if (!inType) {
+      if (/^type\s/.test(raw) && raw.includes('{')) inType = true;
+      continue;
+    }
+    if (raw.startsWith('}')) inType = false;
+    else if (/^\s{2}\w+(\([^)]*\))?:\s*\S/.test(raw)) n++;
+  }
+  return n;
+}
+
+const typeBlockFieldLines = countTypeFieldLines(sdl);
+
+if (parsedFields !== typeBlockFieldLines) {
+  console.error(
+    `error: parsed ${parsedFields} fields but the SDL's type blocks contain ` +
+      `${typeBlockFieldLines} field lines. The parser dropped ${typeBlockFieldLines - parsedFields}. ` +
+      `Do not publish this — the schema reference would be silently incomplete.`,
+  );
+  process.exit(1);
+}
+
 writeFileSync(OUT_PATH, out.join('\n'));
 console.log(
   `Wrote ${OUT_PATH}\n  entities: ${DOMAINS.reduce((n, d) => n + d.entities.length, 0)}` +
-    `\n  types parsed: ${types.size}\n  enums parsed: ${enums.size}`,
+    `\n  types parsed: ${types.size}\n  enums parsed: ${enums.size}` +
+    `\n  fields parsed: ${parsedFields}/${typeBlockFieldLines} (must match)`,
 );

--- a/scripts/gen-vault-indexer-docs.mjs
+++ b/scripts/gen-vault-indexer-docs.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * Regenerate docs/trustless-bitcoin-vault/apis/schema-reference.mdx from the
+ * committed SDL at static/schema/vault-indexer.graphql.
+ *
+ * The SDL itself is produced by scripts/fetch-vault-indexer-schema.mjs, which
+ * introspects the live endpoint. Neither step uses an LLM: a hallucinated field
+ * in a schema reference is indistinguishable from a real one to a reader, so
+ * both stay mechanical.
+ *
+ * Usage: node scripts/gen-vault-indexer-docs.mjs
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const SDL_PATH = resolve(root, 'static/schema/vault-indexer.graphql');
+const OUT_PATH = resolve(root, 'docs/trustless-bitcoin-vault/apis/schema-reference.mdx');
+
+// Entity roots grouped by domain. Ponder derives the plural resolver by appending
+// "s", which is why `stats` pluralises to the odd-looking `statss`.
+const DOMAINS = [
+  {
+    title: 'Core vault',
+    blurb:
+      'The vault lifecycle and the actors that secure it. These entities exist regardless of which DeFi application a vault is used with.',
+    entities: [
+      ['vault', 'vaults', 'A single vault instance and its full lifecycle state.'],
+      ['vaultActivity', 'vaultActivitys', 'Append-only event log of every action taken against a vault.'],
+      ['vaultProvider', 'vaultProviders', 'A registered entity that provides vault services.'],
+      ['vaultProviderStats', 'vaultProviderStatss', 'Aggregated counters per vault provider.'],
+      ['vaultKeeper', 'vaultKeepers', 'A per-application participant in the vault security model.'],
+      ['vaultKeeperApplication', 'vaultKeeperApplications', 'Join between a vault keeper and an application.'],
+      ['universalChallenger', 'universalChallengers', 'A system-wide participant able to challenge invalid claims.'],
+      ['universalChallengerVersion', 'universalChallengerVersions', 'Versioned challenger set.'],
+      ['feeConfig', 'feeConfigs', 'Fee configuration. Currently empty on testnet — see Limits and gotchas.'],
+      ['vaultFeeEscrow', 'vaultFeeEscrows', 'Escrowed fees for one vault. One row per vault.'],
+      ['application', 'applications', 'A DeFi protocol integrated with the vault system.'],
+      ['token', 'tokens', 'A token known to the indexer.'],
+      ['stats', 'statss', 'Protocol-wide totals. Singleton.'],
+      ['protocolState', 'protocolStates', 'Protocol-level singleton state, such as the active vault-core version.'],
+    ],
+  },
+  {
+    title: 'Aave application',
+    blurb:
+      'State for the Aave v4 integration — the first application built on TBV. A vault used as Aave collateral appears in both domains.',
+    entities: [
+      ['aavePosition', 'aavePositions', 'A depositor position, keyed by depositor address.'],
+      ['aavePositionCollateral', 'aavePositionCollaterals', 'One vault pledged as collateral against a position.'],
+      ['aaveVaultStatus', 'aaveVaultStatuss', 'Per-vault usage status within Aave.'],
+      ['aaveUserProxy', 'aaveUserProxys', 'The proxy contract deployed for a user.'],
+      ['aaveReserve', 'aaveReserves', 'An Aave reserve and its parameters.'],
+      ['aaveConfig', 'aaveConfigs', 'Aave integration configuration. Singleton.'],
+    ],
+  },
+];
+
+/** Extract `type Name { ... }` blocks from the SDL into a Map. */
+function parseTypes(sdl) {
+  const types = new Map();
+  const re = /^type (\w+) \{\n([\s\S]*?)^\}/gm;
+  let m;
+  while ((m = re.exec(sdl)) !== null) {
+    const fields = [];
+    for (const line of m[2].split('\n')) {
+      const f = line.match(/^\s{2}(\w+)(\([^)]*\))?:\s*(.+)$/);
+      if (f) fields.push({ name: f[1], args: f[2] ?? '', type: f[3].trim() });
+    }
+    types.set(m[1], fields);
+  }
+  return types;
+}
+
+/** Extract `enum Name { ... }` blocks. */
+function parseEnums(sdl) {
+  const enums = new Map();
+  const re = /^enum (\w+) \{\n([\s\S]*?)^\}/gm;
+  let m;
+  while ((m = re.exec(sdl)) !== null) {
+    enums.set(
+      m[1],
+      m[2].split('\n').map((l) => l.trim()).filter(Boolean),
+    );
+  }
+  return enums;
+}
+
+const sdl = readFileSync(SDL_PATH, 'utf8');
+const types = parseTypes(sdl);
+const enums = parseEnums(sdl);
+
+const esc = (s) => s.replace(/\|/g, '\\|').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const required = (t) => (t.endsWith('!') ? 'yes' : 'no');
+const bare = (t) => t.replace(/[![\]]/g, '');
+
+const out = [];
+out.push(`---
+title: Schema Reference
+sidebar_label: Schema Reference
+sidebar_position: 2
+description: Every entity, field and type exposed by the Babylon vault indexer GraphQL API.
+---
+
+{/*
+  GENERATED FILE — DO NOT EDIT BY HAND.
+  Regenerate with: node scripts/gen-vault-indexer-docs.mjs
+  Source of truth: static/schema/vault-indexer.graphql
+*/}
+
+# Schema Reference
+
+Every entity exposed by the vault indexer, generated from the deployed schema.
+
+Each entity has two resolvers:
+
+- **Singular** — \`vault(id: "0x…")\` returns one record or \`null\`
+- **Plural** — \`vaults(where:, orderBy:, orderDirection:, limit:, offset:)\` returns a page
+
+A page always carries \`items\`, \`totalCount\` and \`pageInfo\`. \`limit\` caps at
+1000; see [Limits and gotchas](./limits-and-gotchas.mdx) before writing a client.
+
+:::note Types are lower-case
+Ponder generates this API from the indexer's table definitions, so type names
+match the table names and are lower-case (\`vault\`, not \`Vault\`). The plural of
+\`stats\` is \`statss\` for the same reason — the generator appends an \`s\`.
+:::
+`);
+
+for (const domain of DOMAINS) {
+  out.push(`\n## ${domain.title}\n\n${domain.blurb}\n`);
+  for (const [name, plural, blurb] of domain.entities) {
+    const fields = types.get(name);
+    if (!fields) {
+      throw new Error(
+        `Entity "${name}" is missing from the SDL. The deployed schema changed — ` +
+          `re-run scripts/fetch-vault-indexer-schema.mjs and update DOMAINS in this script.`,
+      );
+    }
+    out.push(`\n### \`${name}\`\n`);
+    out.push(`${blurb}\n`);
+    out.push(`Query with \`${name}(…)\` or \`${plural}(…)\`.\n`);
+    out.push(`| Field | Type | Required |`);
+    out.push(`| --- | --- | --- |`);
+    for (const f of fields) {
+      const label = f.args ? `${f.name}(…)` : f.name;
+      out.push(`| \`${label}\` | \`${esc(f.type)}\` | ${required(f.type)} |`);
+    }
+    out.push('');
+    // Surface enum values inline — a reader filtering on `status` needs them here,
+    // not in a separate section.
+    const used = [...new Set(fields.map((f) => bare(f.type)).filter((t) => enums.has(t)))];
+    for (const e of used) {
+      out.push(`\n\`${e}\` values: ${enums.get(e).map((v) => `\`${v}\``).join(' · ')}\n`);
+    }
+  }
+}
+
+out.push(`\n## Full SDL\n`);
+out.push(
+  `The complete schema is committed at [\`/schema/vault-indexer.graphql\`](/schema/vault-indexer.graphql).\n`,
+);
+out.push(
+  `Introspection is available but depth-capped — see [Limits and gotchas](./limits-and-gotchas.mdx) for the four short queries that reconstruct it.\n`,
+);
+
+writeFileSync(OUT_PATH, out.join('\n'));
+console.log(
+  `Wrote ${OUT_PATH}\n  entities: ${DOMAINS.reduce((n, d) => n + d.entities.length, 0)}` +
+    `\n  types parsed: ${types.size}\n  enums parsed: ${enums.size}`,
+);

--- a/scripts/verify-vault-indexer-queries.mjs
+++ b/scripts/verify-vault-indexer-queries.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Execute every GraphQL example in the vault indexer docs against the live
+ * endpoint, and fail if any of them does not run.
+ *
+ * This is the correctness gate for LLM-drafted documentation. A GraphQL endpoint
+ * is an unusually good verifier — it rejects an unknown field with an exact error
+ * and often suggests the right name — which turns "did the model invent this?"
+ * from a judgement call into a pass/fail test.
+ *
+ * Any fenced ```graphql block is executed. Mark a block as a non-executable
+ * illustration with ```graphql title="skip-verify" and it is reported as skipped.
+ *
+ * Usage: node scripts/verify-vault-indexer-queries.mjs [file...]
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, dirname, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DOCS_DIR = resolve(root, 'docs/trustless-bitcoin-vault/apis');
+const ENDPOINT =
+  process.env.VAULT_INDEXER_ENDPOINT ??
+  'https://babylon-vault-indexer-api.testnet.babylonlabs.io/';
+const USER_AGENT = 'babylonlabs-docs-query-verify/1.0 (+https://docs.babylonlabs.io)';
+
+// Mirrors the deployment's limits (babylon-vault-indexer src/api/index.ts).
+// Checked locally so a doc example that would be rejected is caught as a doc bug
+// rather than surfacing as a confusing runtime error for a reader.
+const MAX_DEPTH = 10;
+
+const files = process.argv.slice(2).length
+  ? process.argv.slice(2)
+  : readdirSync(DOCS_DIR)
+      .filter((f) => f.endsWith('.mdx'))
+      .map((f) => resolve(DOCS_DIR, f));
+
+/** Pull fenced graphql blocks, with their line number and meta string. */
+function extractBlocks(text) {
+  const blocks = [];
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const open = lines[i].match(/^```graphql(.*)$/);
+    if (!open) continue;
+    const meta = open[1] ?? '';
+    const body = [];
+    let j = i + 1;
+    for (; j < lines.length && !/^```\s*$/.test(lines[j]); j++) body.push(lines[j]);
+    blocks.push({ line: i + 1, meta, query: body.join('\n') });
+    i = j;
+  }
+  return blocks;
+}
+
+/** Brace-nesting depth, which is what the server's depth rule counts. */
+function queryDepth(q) {
+  let depth = 0;
+  let max = 0;
+  for (const ch of q.replace(/#[^\n]*/g, '')) {
+    if (ch === '{') max = Math.max(max, ++depth);
+    else if (ch === '}') depth--;
+  }
+  return max;
+}
+
+async function run(query) {
+  const res = await fetch(ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'User-Agent': USER_AGENT },
+    body: JSON.stringify({ query }),
+  });
+  if (!res.ok) return { ok: false, reason: `HTTP ${res.status}` };
+  const body = await res.json();
+  if (body.errors) return { ok: false, reason: body.errors.map((e) => e.message).join('; ') };
+  return { ok: true, body };
+}
+
+let pass = 0;
+let fail = 0;
+let skip = 0;
+const failures = [];
+
+for (const file of files) {
+  const blocks = extractBlocks(readFileSync(file, 'utf8'));
+  if (!blocks.length) continue;
+  console.log(`\n${basename(file)}`);
+  for (const b of blocks) {
+    const label = `  L${String(b.line).padStart(4)}`;
+    if (/skip-verify/.test(b.meta)) {
+      console.log(`${label}  SKIP  (marked non-executable)`);
+      skip++;
+      continue;
+    }
+    const d = queryDepth(b.query);
+    if (d > MAX_DEPTH) {
+      console.log(`${label}  FAIL  depth ${d} exceeds the endpoint cap of ${MAX_DEPTH}`);
+      failures.push({ file: basename(file), line: b.line, reason: `depth ${d} > ${MAX_DEPTH}` });
+      fail++;
+      continue;
+    }
+    const r = await run(b.query);
+    if (r.ok) {
+      console.log(`${label}  PASS  depth ${d}`);
+      pass++;
+    } else {
+      console.log(`${label}  FAIL  ${r.reason}`);
+      failures.push({ file: basename(file), line: b.line, reason: r.reason });
+      fail++;
+    }
+  }
+}
+
+console.log(`\n${'-'.repeat(60)}\npass ${pass}   fail ${fail}   skip ${skip}`);
+if (fail) {
+  console.log('\nFailures:');
+  for (const f of failures) console.log(`  ${f.file}:${f.line} — ${f.reason}`);
+  process.exit(1);
+}
+console.log('All executable examples ran against the live endpoint.');

--- a/scripts/verify-vault-indexer-queries.mjs
+++ b/scripts/verify-vault-indexer-queries.mjs
@@ -64,16 +64,69 @@ function queryDepth(q) {
   return max;
 }
 
-async function run(query) {
-  const res = await fetch(ENDPOINT, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'User-Agent': USER_AGENT },
-    body: JSON.stringify({ query }),
-  });
-  if (!res.ok) return { ok: false, reason: `HTTP ${res.status}` };
-  const body = await res.json();
-  if (body.errors) return { ok: false, reason: body.errors.map((e) => e.message).join('; ') };
-  return { ok: true, body };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const backoff = (attempt) => 500 * 2 ** (attempt - 1);
+
+/**
+ * Execute one query, retrying only on transport-level failures.
+ *
+ * The distinction matters, because this script is a gate. A GraphQL error means
+ * the documentation is wrong and must never be retried away. A 429, a 5xx or a
+ * dropped connection says nothing about the documentation, and failing on one
+ * would block a legitimate regeneration — the endpoint does throttle a burst,
+ * and this script sends every example on the page back to back.
+ */
+async function run(query, attempts = 4) {
+  let last = 'unknown error';
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    let res;
+    try {
+      res = await fetch(ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'User-Agent': USER_AGENT },
+        body: JSON.stringify({ query }),
+      });
+    } catch (err) {
+      last = `network error: ${err.message}`;
+      if (attempt < attempts) await sleep(backoff(attempt));
+      continue;
+    }
+
+    if (res.status === 429 || res.status >= 500) {
+      last = `HTTP ${res.status}`;
+      if (attempt < attempts) {
+        const retryAfter = Number(res.headers.get('retry-after'));
+        await sleep(Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : backoff(attempt));
+      }
+      continue;
+    }
+
+    // 403 is the blocked-user-agent trap. Retrying will never help, and the
+    // generic "HTTP 403" reads as an outage, so name the real cause here.
+    if (res.status === 403) {
+      return { ok: false, reason: 'HTTP 403 — the edge blocked this User-Agent. Not an outage or an auth wall.' };
+    }
+    if (!res.ok) return { ok: false, reason: `HTTP ${res.status}` };
+
+    let body;
+    try {
+      body = await res.json();
+    } catch {
+      return { ok: false, reason: 'response was not JSON' };
+    }
+    // A GraphQL error is a documentation bug. Return it, never retry it.
+    if (body.errors) return { ok: false, reason: body.errors.map((e) => e.message).join('; ') };
+    // Absence of `errors` is not success. A body of `{}` — or `{"data": null}`
+    // from a proxy or a partial failure — would otherwise be recorded as a pass,
+    // which is the one outcome this gate must never produce.
+    if (body.data === undefined || body.data === null) {
+      return { ok: false, reason: 'response carried neither `data` nor `errors`' };
+    }
+    return { ok: true, body };
+  }
+
+  return { ok: false, reason: `${last} after ${attempts} attempts` };
 }
 
 let pass = 0;
@@ -99,6 +152,9 @@ for (const file of files) {
       fail++;
       continue;
     }
+    // A small gap between examples. This is a shared public testnet endpoint,
+    // and the whole page is sent back to back.
+    await sleep(100);
     const r = await run(b.query);
     if (r.ok) {
       console.log(`${label}  PASS  depth ${d}`);

--- a/sidebars-default.js
+++ b/sidebars-default.js
@@ -240,6 +240,33 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'APIs',
+      collapsible: true,
+      collapsed: true,
+      className: 'specs_sidebar_header',
+      // Plain links, not doc IDs: these pages own the stakingApi / babylonRpc /
+      // cometBFT sidebars, so referencing them by ID would place one doc in two
+      // sidebars. Their URLs are unchanged by this move.
+      items: [
+        {
+          type: 'link',
+          label: 'Babylon Staking API',
+          href: '/api/staking-api/babylon-staking-api',
+        },
+        {
+          type: 'link',
+          label: 'Babylon gRPC',
+          href: '/api/babylon-gRPC/babylon-grpc-api-docs',
+        },
+        {
+          type: 'link',
+          label: 'CometBFT',
+          href: '/api/comet-bft/babylon-grpc-api-docs',
+        },
+      ],
+    },
+    {
+      type: 'category',
       label: 'Support',
       collapsible: true,
       collapsed: true,
@@ -293,6 +320,23 @@ const sidebars = {
         'trustless-bitcoin-vault/use-for-lending/withdraw-and-redeem',
         'trustless-bitcoin-vault/use-for-lending/liquidation-risk',
         'trustless-bitcoin-vault/use-for-lending/faq',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'APIs',
+      collapsible: true,
+      collapsed: true,
+      className: 'specs_sidebar_header',
+      link: {
+        type: 'doc',
+        id: 'trustless-bitcoin-vault/apis/vault-indexer-api',
+      },
+      items: [
+        'trustless-bitcoin-vault/apis/vault-indexer-api',
+        'trustless-bitcoin-vault/apis/schema-reference',
+        'trustless-bitcoin-vault/apis/query-cookbook',
+        'trustless-bitcoin-vault/apis/limits-and-gotchas',
       ],
     },
     {

--- a/sidebars-default.js
+++ b/sidebars-default.js
@@ -243,7 +243,7 @@ const sidebars = {
       label: 'APIs',
       collapsible: true,
       collapsed: true,
-      className: 'specs_sidebar_header',
+      className: 'developers_sidebar_header',
       // Plain links, not doc IDs: these pages own the stakingApi / babylonRpc /
       // cometBFT sidebars, so referencing them by ID would place one doc in two
       // sidebars. Their URLs are unchanged by this move.
@@ -327,7 +327,7 @@ const sidebars = {
       label: 'APIs',
       collapsible: true,
       collapsed: true,
-      className: 'specs_sidebar_header',
+      className: 'developers_sidebar_header',
       link: {
         type: 'doc',
         id: 'trustless-bitcoin-vault/apis/vault-indexer-api',
@@ -345,7 +345,7 @@ const sidebars = {
       label: 'Technical Details',
       collapsible: true,
       collapsed: true,
-      className: 'specs_sidebar_header',
+      className: 'architecture_sidebar_header',
       items: [
         'trustless-bitcoin-vault/technical-details/protocol-architecture',
         'trustless-bitcoin-vault/technical-details/protocol-actors',

--- a/sidebars-default.js
+++ b/sidebars-default.js
@@ -334,6 +334,7 @@ const sidebars = {
       },
       items: [
         'trustless-bitcoin-vault/apis/vault-indexer-api',
+        'trustless-bitcoin-vault/apis/use-cases',
         'trustless-bitcoin-vault/apis/schema-reference',
         'trustless-bitcoin-vault/apis/query-cookbook',
         'trustless-bitcoin-vault/apis/limits-and-gotchas',

--- a/static/schema/vault-indexer.graphql
+++ b/static/schema/vault-indexer.graphql
@@ -1,0 +1,2016 @@
+type aaveConfig {
+  id: Int!
+  adapterAddress: String!
+  vaultBtcAddress: String!
+  btcVaultRegistryAddress: String!
+  btcVaultCoreSpokeAddress: String!
+  vaultBtcReserveId: BigInt!
+}
+
+input aaveConfigFilter {
+  AND: [aaveConfigFilter]
+  OR: [aaveConfigFilter]
+  id: Int
+  id_not: Int
+  id_in: [Int]
+  id_not_in: [Int]
+  id_gt: Int
+  id_lt: Int
+  id_gte: Int
+  id_lte: Int
+  adapterAddress: String
+  adapterAddress_not: String
+  adapterAddress_in: [String]
+  adapterAddress_not_in: [String]
+  adapterAddress_contains: String
+  adapterAddress_not_contains: String
+  adapterAddress_starts_with: String
+  adapterAddress_ends_with: String
+  adapterAddress_not_starts_with: String
+  adapterAddress_not_ends_with: String
+  vaultBtcAddress: String
+  vaultBtcAddress_not: String
+  vaultBtcAddress_in: [String]
+  vaultBtcAddress_not_in: [String]
+  vaultBtcAddress_contains: String
+  vaultBtcAddress_not_contains: String
+  vaultBtcAddress_starts_with: String
+  vaultBtcAddress_ends_with: String
+  vaultBtcAddress_not_starts_with: String
+  vaultBtcAddress_not_ends_with: String
+  btcVaultRegistryAddress: String
+  btcVaultRegistryAddress_not: String
+  btcVaultRegistryAddress_in: [String]
+  btcVaultRegistryAddress_not_in: [String]
+  btcVaultRegistryAddress_contains: String
+  btcVaultRegistryAddress_not_contains: String
+  btcVaultRegistryAddress_starts_with: String
+  btcVaultRegistryAddress_ends_with: String
+  btcVaultRegistryAddress_not_starts_with: String
+  btcVaultRegistryAddress_not_ends_with: String
+  btcVaultCoreSpokeAddress: String
+  btcVaultCoreSpokeAddress_not: String
+  btcVaultCoreSpokeAddress_in: [String]
+  btcVaultCoreSpokeAddress_not_in: [String]
+  btcVaultCoreSpokeAddress_contains: String
+  btcVaultCoreSpokeAddress_not_contains: String
+  btcVaultCoreSpokeAddress_starts_with: String
+  btcVaultCoreSpokeAddress_ends_with: String
+  btcVaultCoreSpokeAddress_not_starts_with: String
+  btcVaultCoreSpokeAddress_not_ends_with: String
+  vaultBtcReserveId: BigInt
+  vaultBtcReserveId_not: BigInt
+  vaultBtcReserveId_in: [BigInt]
+  vaultBtcReserveId_not_in: [BigInt]
+  vaultBtcReserveId_gt: BigInt
+  vaultBtcReserveId_lt: BigInt
+  vaultBtcReserveId_gte: BigInt
+  vaultBtcReserveId_lte: BigInt
+}
+
+type aaveConfigPage {
+  items: [aaveConfig!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type aavePosition {
+  depositorAddress: String!
+  proxyContract: String!
+  totalCollateral: BigInt!
+  createdAt: BigInt!
+  updatedAt: BigInt!
+  blockNumber: BigInt!
+  transactionHash: String!
+  collaterals(where: aavePositionCollateralFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): aavePositionCollateralPage
+}
+
+type aavePositionCollateral {
+  depositorAddress: String!
+  vaultId: String!
+  amount: BigInt!
+  addedAt: BigInt!
+  removedAt: BigInt
+  liquidationIndex: Int!
+  blockNumber: BigInt!
+  transactionHash: String!
+  position: aavePosition
+  vault: vault
+}
+
+input aavePositionCollateralFilter {
+  AND: [aavePositionCollateralFilter]
+  OR: [aavePositionCollateralFilter]
+  depositorAddress: String
+  depositorAddress_not: String
+  depositorAddress_in: [String]
+  depositorAddress_not_in: [String]
+  depositorAddress_contains: String
+  depositorAddress_not_contains: String
+  depositorAddress_starts_with: String
+  depositorAddress_ends_with: String
+  depositorAddress_not_starts_with: String
+  depositorAddress_not_ends_with: String
+  vaultId: String
+  vaultId_not: String
+  vaultId_in: [String]
+  vaultId_not_in: [String]
+  vaultId_contains: String
+  vaultId_not_contains: String
+  vaultId_starts_with: String
+  vaultId_ends_with: String
+  vaultId_not_starts_with: String
+  vaultId_not_ends_with: String
+  amount: BigInt
+  amount_not: BigInt
+  amount_in: [BigInt]
+  amount_not_in: [BigInt]
+  amount_gt: BigInt
+  amount_lt: BigInt
+  amount_gte: BigInt
+  amount_lte: BigInt
+  addedAt: BigInt
+  addedAt_not: BigInt
+  addedAt_in: [BigInt]
+  addedAt_not_in: [BigInt]
+  addedAt_gt: BigInt
+  addedAt_lt: BigInt
+  addedAt_gte: BigInt
+  addedAt_lte: BigInt
+  removedAt: BigInt
+  removedAt_not: BigInt
+  removedAt_in: [BigInt]
+  removedAt_not_in: [BigInt]
+  removedAt_gt: BigInt
+  removedAt_lt: BigInt
+  removedAt_gte: BigInt
+  removedAt_lte: BigInt
+  liquidationIndex: Int
+  liquidationIndex_not: Int
+  liquidationIndex_in: [Int]
+  liquidationIndex_not_in: [Int]
+  liquidationIndex_gt: Int
+  liquidationIndex_lt: Int
+  liquidationIndex_gte: Int
+  liquidationIndex_lte: Int
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_in: [BigInt]
+  blockNumber_not_in: [BigInt]
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  transactionHash: String
+  transactionHash_not: String
+  transactionHash_in: [String]
+  transactionHash_not_in: [String]
+  transactionHash_contains: String
+  transactionHash_not_contains: String
+  transactionHash_starts_with: String
+  transactionHash_ends_with: String
+  transactionHash_not_starts_with: String
+  transactionHash_not_ends_with: String
+}
+
+type aavePositionCollateralPage {
+  items: [aavePositionCollateral!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+input aavePositionFilter {
+  AND: [aavePositionFilter]
+  OR: [aavePositionFilter]
+  depositorAddress: String
+  depositorAddress_not: String
+  depositorAddress_in: [String]
+  depositorAddress_not_in: [String]
+  depositorAddress_contains: String
+  depositorAddress_not_contains: String
+  depositorAddress_starts_with: String
+  depositorAddress_ends_with: String
+  depositorAddress_not_starts_with: String
+  depositorAddress_not_ends_with: String
+  proxyContract: String
+  proxyContract_not: String
+  proxyContract_in: [String]
+  proxyContract_not_in: [String]
+  proxyContract_contains: String
+  proxyContract_not_contains: String
+  proxyContract_starts_with: String
+  proxyContract_ends_with: String
+  proxyContract_not_starts_with: String
+  proxyContract_not_ends_with: String
+  totalCollateral: BigInt
+  totalCollateral_not: BigInt
+  totalCollateral_in: [BigInt]
+  totalCollateral_not_in: [BigInt]
+  totalCollateral_gt: BigInt
+  totalCollateral_lt: BigInt
+  totalCollateral_gte: BigInt
+  totalCollateral_lte: BigInt
+  createdAt: BigInt
+  createdAt_not: BigInt
+  createdAt_in: [BigInt]
+  createdAt_not_in: [BigInt]
+  createdAt_gt: BigInt
+  createdAt_lt: BigInt
+  createdAt_gte: BigInt
+  createdAt_lte: BigInt
+  updatedAt: BigInt
+  updatedAt_not: BigInt
+  updatedAt_in: [BigInt]
+  updatedAt_not_in: [BigInt]
+  updatedAt_gt: BigInt
+  updatedAt_lt: BigInt
+  updatedAt_gte: BigInt
+  updatedAt_lte: BigInt
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_in: [BigInt]
+  blockNumber_not_in: [BigInt]
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  transactionHash: String
+  transactionHash_not: String
+  transactionHash_in: [String]
+  transactionHash_not_in: [String]
+  transactionHash_contains: String
+  transactionHash_not_contains: String
+  transactionHash_starts_with: String
+  transactionHash_ends_with: String
+  transactionHash_not_starts_with: String
+  transactionHash_not_ends_with: String
+}
+
+type aavePositionPage {
+  items: [aavePosition!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type aaveReserve {
+  id: BigInt!
+  underlying: String!
+  hub: String!
+  assetId: Int!
+  decimals: Int!
+  dynamicConfigKey: BigInt!
+  paused: Boolean!
+  frozen: Boolean!
+  borrowable: Boolean!
+  collateralRisk: Int!
+  collateralFactor: Int!
+  createdAt: BigInt!
+  updatedAt: BigInt!
+  blockNumber: BigInt!
+  underlyingToken: token
+}
+
+input aaveReserveFilter {
+  AND: [aaveReserveFilter]
+  OR: [aaveReserveFilter]
+  id: BigInt
+  id_not: BigInt
+  id_in: [BigInt]
+  id_not_in: [BigInt]
+  id_gt: BigInt
+  id_lt: BigInt
+  id_gte: BigInt
+  id_lte: BigInt
+  underlying: String
+  underlying_not: String
+  underlying_in: [String]
+  underlying_not_in: [String]
+  underlying_contains: String
+  underlying_not_contains: String
+  underlying_starts_with: String
+  underlying_ends_with: String
+  underlying_not_starts_with: String
+  underlying_not_ends_with: String
+  hub: String
+  hub_not: String
+  hub_in: [String]
+  hub_not_in: [String]
+  hub_contains: String
+  hub_not_contains: String
+  hub_starts_with: String
+  hub_ends_with: String
+  hub_not_starts_with: String
+  hub_not_ends_with: String
+  assetId: Int
+  assetId_not: Int
+  assetId_in: [Int]
+  assetId_not_in: [Int]
+  assetId_gt: Int
+  assetId_lt: Int
+  assetId_gte: Int
+  assetId_lte: Int
+  decimals: Int
+  decimals_not: Int
+  decimals_in: [Int]
+  decimals_not_in: [Int]
+  decimals_gt: Int
+  decimals_lt: Int
+  decimals_gte: Int
+  decimals_lte: Int
+  dynamicConfigKey: BigInt
+  dynamicConfigKey_not: BigInt
+  dynamicConfigKey_in: [BigInt]
+  dynamicConfigKey_not_in: [BigInt]
+  dynamicConfigKey_gt: BigInt
+  dynamicConfigKey_lt: BigInt
+  dynamicConfigKey_gte: BigInt
+  dynamicConfigKey_lte: BigInt
+  paused: Boolean
+  paused_not: Boolean
+  paused_in: [Boolean]
+  paused_not_in: [Boolean]
+  frozen: Boolean
+  frozen_not: Boolean
+  frozen_in: [Boolean]
+  frozen_not_in: [Boolean]
+  borrowable: Boolean
+  borrowable_not: Boolean
+  borrowable_in: [Boolean]
+  borrowable_not_in: [Boolean]
+  collateralRisk: Int
+  collateralRisk_not: Int
+  collateralRisk_in: [Int]
+  collateralRisk_not_in: [Int]
+  collateralRisk_gt: Int
+  collateralRisk_lt: Int
+  collateralRisk_gte: Int
+  collateralRisk_lte: Int
+  collateralFactor: Int
+  collateralFactor_not: Int
+  collateralFactor_in: [Int]
+  collateralFactor_not_in: [Int]
+  collateralFactor_gt: Int
+  collateralFactor_lt: Int
+  collateralFactor_gte: Int
+  collateralFactor_lte: Int
+  createdAt: BigInt
+  createdAt_not: BigInt
+  createdAt_in: [BigInt]
+  createdAt_not_in: [BigInt]
+  createdAt_gt: BigInt
+  createdAt_lt: BigInt
+  createdAt_gte: BigInt
+  createdAt_lte: BigInt
+  updatedAt: BigInt
+  updatedAt_not: BigInt
+  updatedAt_in: [BigInt]
+  updatedAt_not_in: [BigInt]
+  updatedAt_gt: BigInt
+  updatedAt_lt: BigInt
+  updatedAt_gte: BigInt
+  updatedAt_lte: BigInt
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_in: [BigInt]
+  blockNumber_not_in: [BigInt]
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+}
+
+type aaveReservePage {
+  items: [aaveReserve!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type aaveUserProxy {
+  user: String!
+  proxy: String!
+  createdAt: BigInt!
+  blockNumber: BigInt!
+  transactionHash: String!
+}
+
+input aaveUserProxyFilter {
+  AND: [aaveUserProxyFilter]
+  OR: [aaveUserProxyFilter]
+  user: String
+  user_not: String
+  user_in: [String]
+  user_not_in: [String]
+  user_contains: String
+  user_not_contains: String
+  user_starts_with: String
+  user_ends_with: String
+  user_not_starts_with: String
+  user_not_ends_with: String
+  proxy: String
+  proxy_not: String
+  proxy_in: [String]
+  proxy_not_in: [String]
+  proxy_contains: String
+  proxy_not_contains: String
+  proxy_starts_with: String
+  proxy_ends_with: String
+  proxy_not_starts_with: String
+  proxy_not_ends_with: String
+  createdAt: BigInt
+  createdAt_not: BigInt
+  createdAt_in: [BigInt]
+  createdAt_not_in: [BigInt]
+  createdAt_gt: BigInt
+  createdAt_lt: BigInt
+  createdAt_gte: BigInt
+  createdAt_lte: BigInt
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_in: [BigInt]
+  blockNumber_not_in: [BigInt]
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  transactionHash: String
+  transactionHash_not: String
+  transactionHash_in: [String]
+  transactionHash_not_in: [String]
+  transactionHash_contains: String
+  transactionHash_not_contains: String
+  transactionHash_starts_with: String
+  transactionHash_ends_with: String
+  transactionHash_not_starts_with: String
+  transactionHash_not_ends_with: String
+}
+
+type aaveUserProxyPage {
+  items: [aaveUserProxy!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type aaveVaultStatus {
+  vaultId: String!
+  applicationEntryPoint: String!
+  status: aaveVaultUsageStatus!
+  metadata: JSON
+  updatedAt: BigInt!
+  vault: vault
+}
+
+input aaveVaultStatusFilter {
+  AND: [aaveVaultStatusFilter]
+  OR: [aaveVaultStatusFilter]
+  vaultId: String
+  vaultId_not: String
+  vaultId_in: [String]
+  vaultId_not_in: [String]
+  vaultId_contains: String
+  vaultId_not_contains: String
+  vaultId_starts_with: String
+  vaultId_ends_with: String
+  vaultId_not_starts_with: String
+  vaultId_not_ends_with: String
+  applicationEntryPoint: String
+  applicationEntryPoint_not: String
+  applicationEntryPoint_in: [String]
+  applicationEntryPoint_not_in: [String]
+  applicationEntryPoint_contains: String
+  applicationEntryPoint_not_contains: String
+  applicationEntryPoint_starts_with: String
+  applicationEntryPoint_ends_with: String
+  applicationEntryPoint_not_starts_with: String
+  applicationEntryPoint_not_ends_with: String
+  status: aaveVaultUsageStatus
+  status_not: aaveVaultUsageStatus
+  status_in: [aaveVaultUsageStatus]
+  status_not_in: [aaveVaultUsageStatus]
+  updatedAt: BigInt
+  updatedAt_not: BigInt
+  updatedAt_in: [BigInt]
+  updatedAt_not_in: [BigInt]
+  updatedAt_gt: BigInt
+  updatedAt_lt: BigInt
+  updatedAt_gte: BigInt
+  updatedAt_lte: BigInt
+}
+
+type aaveVaultStatusPage {
+  items: [aaveVaultStatus!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+enum aaveVaultUsageStatus {
+  collateralized
+  llp_owned
+  redeemed
+}
+
+type application {
+  id: String!
+  name: String
+  latestVKVersion: Int
+  totalCapBTC: BigInt
+  perAddressCapBTC: BigInt
+  status: applicationStatus!
+  registeredAt: BigInt!
+  blockNumber: BigInt!
+  transactionHash: String!
+}
+
+input applicationFilter {
+  AND: [applicationFilter]
+  OR: [applicationFilter]
+  id: String
+  id_not: String
+  id_in: [String]
+  id_not_in: [String]
+  id_contains: String
+  id_not_contains: String
+  id_starts_with: String
+  id_ends_with: String
+  id_not_starts_with: String
+  id_not_ends_with: String
+  name: String
+  name_not: String
+  name_in: [String]
+  name_not_in: [String]
+  name_contains: String
+  name_not_contains: String
+  name_starts_with: String
+  name_ends_with: String
+  name_not_starts_with: String
+  name_not_ends_with: String
+  latestVKVersion: Int
+  latestVKVersion_not: Int
+  latestVKVersion_in: [Int]
+  latestVKVersion_not_in: [Int]
+  latestVKVersion_gt: Int
+  latestVKVersion_lt: Int
+  latestVKVersion_gte: Int
+  latestVKVersion_lte: Int
+  totalCapBTC: BigInt
+  totalCapBTC_not: BigInt
+  totalCapBTC_in: [BigInt]
+  totalCapBTC_not_in: [BigInt]
+  totalCapBTC_gt: BigInt
+  totalCapBTC_lt: BigInt
+  totalCapBTC_gte: BigInt
+  totalCapBTC_lte: BigInt
+  perAddressCapBTC: BigInt
+  perAddressCapBTC_not: BigInt
+  perAddressCapBTC_in: [BigInt]
+  perAddressCapBTC_not_in: [BigInt]
+  perAddressCapBTC_gt: BigInt
+  perAddressCapBTC_lt: BigInt
+  perAddressCapBTC_gte: BigInt
+  perAddressCapBTC_lte: BigInt
+  status: applicationStatus
+  status_not: applicationStatus
+  status_in: [applicationStatus]
+  status_not_in: [applicationStatus]
+  registeredAt: BigInt
+  registeredAt_not: BigInt
+  registeredAt_in: [BigInt]
+  registeredAt_not_in: [BigInt]
+  registeredAt_gt: BigInt
+  registeredAt_lt: BigInt
+  registeredAt_gte: BigInt
+  registeredAt_lte: BigInt
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_in: [BigInt]
+  blockNumber_not_in: [BigInt]
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  transactionHash: String
+  transactionHash_not: String
+  transactionHash_in: [String]
+  transactionHash_not_in: [String]
+  transactionHash_contains: String
+  transactionHash_not_contains: String
+  transactionHash_starts_with: String
+  transactionHash_ends_with: String
+  transactionHash_not_starts_with: String
+  transactionHash_not_ends_with: String
+}
+
+type applicationPage {
+  items: [application!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+enum applicationStatus {
+  none
+  active
+  paused
+}
+
+scalar BigInt
+
+""" The `Boolean` scalar type represents `true` or `false`. """
+scalar Boolean
+
+type feeConfig {
+  id: String!
+  vpFeeRate: BigInt!
+  ucFeeRate: BigInt!
+  avkFeeRate: BigInt!
+  protocolPegInFeeRate: BigInt!
+  vpRegistrationFee: BigInt!
+  updatedAt: BigInt!
+  blockNumber: BigInt!
+}
+
+input feeConfigFilter {
+  AND: [feeConfigFilter]
+  OR: [feeConfigFilter]
+  id: String
+  id_not: String
+  id_in: [String]
+  id_not_in: [String]
+  id_contains: String
+  id_not_contains: String
+  id_starts_with: String
+  id_ends_with: String
+  id_not_starts_with: String
+  id_not_ends_with: String
+  vpFeeRate: BigInt
+  vpFeeRate_not: BigInt
+  vpFeeRate_in: [BigInt]
+  vpFeeRate_not_in: [BigInt]
+  vpFeeRate_gt: BigInt
+  vpFeeRate_lt: BigInt
+  vpFeeRate_gte: BigInt
+  vpFeeRate_lte: BigInt
+  ucFeeRate: BigInt
+  ucFeeRate_not: BigInt
+  ucFeeRate_in: [BigInt]
+  ucFeeRate_not_in: [BigInt]
+  ucFeeRate_gt: BigInt
+  ucFeeRate_lt: BigInt
+  ucFeeRate_gte: BigInt
+  ucFeeRate_lte: BigInt
+  avkFeeRate: BigInt
+  avkFeeRate_not: BigInt
+  avkFeeRate_in: [BigInt]
+  avkFeeRate_not_in: [BigInt]
+  avkFeeRate_gt: BigInt
+  avkFeeRate_lt: BigInt
+  avkFeeRate_gte: BigInt
+  avkFeeRate_lte: BigInt
+  protocolPegInFeeRate: BigInt
+  protocolPegInFeeRate_not: BigInt
+  protocolPegInFeeRate_in: [BigInt]
+  protocolPegInFeeRate_not_in: [BigInt]
+  protocolPegInFeeRate_gt: BigInt
+  protocolPegInFeeRate_lt: BigInt
+  protocolPegInFeeRate_gte: BigInt
+  protocolPegInFeeRate_lte: BigInt
+  vpRegistrationFee: BigInt
+  vpRegistrationFee_not: BigInt
+  vpRegistrationFee_in: [BigInt]
+  vpRegistrationFee_not_in: [BigInt]
+  vpRegistrationFee_gt: BigInt
+  vpRegistrationFee_lt: BigInt
+  vpRegistrationFee_gte: BigInt
+  vpRegistrationFee_lte: BigInt
+  updatedAt: BigInt
+  updatedAt_not: BigInt
+  updatedAt_in: [BigInt]
+  updatedAt_not_in: [BigInt]
+  updatedAt_gt: BigInt
+  updatedAt_lt: BigInt
+  updatedAt_gte: BigInt
+  updatedAt_lte: BigInt
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_in: [BigInt]
+  blockNumber_not_in: [BigInt]
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+}
+
+type feeConfigPage {
+  items: [feeConfig!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+enum feeEscrowStatus {
+  escrowed
+  distributed
+  refunded
+  forfeited
+}
+
+""" The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. """
+scalar Int
+
+""" The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). """
+scalar JSON
+
+type Meta {
+  status: JSON
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
+}
+
+type protocolState {
+  id: String!
+  activeVaultCoreVersion: Int!
+  updatedAt: BigInt!
+  blockNumber: BigInt!
+  transactionHash: String!
+}
+
+input protocolStateFilter {
+  AND: [protocolStateFilter]
+  OR: [protocolStateFilter]
+  id: String
+  id_not: String
+  id_in: [String]
+  id_not_in: [String]
+  id_contains: String
+  id_not_contains: String
+  id_starts_with: String
+  id_ends_with: String
+  id_not_starts_with: String
+  id_not_ends_with: String
+  activeVaultCoreVersion: Int
+  activeVaultCoreVersion_not: Int
+  activeVaultCoreVersion_in: [Int]
+  activeVaultCoreVersion_not_in: [Int]
+  activeVaultCoreVersion_gt: Int
+  activeVaultCoreVersion_lt: Int
+  activeVaultCoreVersion_gte: Int
+  activeVaultCoreVersion_lte: Int
+  updatedAt: BigInt
+  updatedAt_not: BigInt
+  updatedAt_in: [BigInt]
+  updatedAt_not_in: [BigInt]
+  updatedAt_gt: BigInt
+  updatedAt_lt: BigInt
+  updatedAt_gte: BigInt
+  updatedAt_lte: BigInt
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_in: [BigInt]
+  blockNumber_not_in: [BigInt]
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  transactionHash: String
+  transactionHash_not: String
+  transactionHash_in: [String]
+  transactionHash_not_in: [String]
+  transactionHash_contains: String
+  transactionHash_not_contains: String
+  transactionHash_starts_with: String
+  transactionHash_ends_with: String
+  transactionHash_not_starts_with: String
+  transactionHash_not_ends_with: String
+}
+
+type protocolStatePage {
+  items: [protocolState!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type Query {
+  token(address: String!): token
+  tokens(where: tokenFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): tokenPage!
+  application(id: String!): application
+  applications(where: applicationFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): applicationPage!
+  vaultKeeper(id: String!): vaultKeeper
+  vaultKeepers(where: vaultKeeperFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): vaultKeeperPage!
+  vaultKeeperApplication(id: String!): vaultKeeperApplication
+  vaultKeeperApplications(where: vaultKeeperApplicationFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): vaultKeeperApplicationPage!
+  universalChallenger(id: String!): universalChallenger
+  universalChallengers(where: universalChallengerFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): universalChallengerPage!
+  universalChallengerVersion(id: String!): universalChallengerVersion
+  universalChallengerVersions(where: universalChallengerVersionFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): universalChallengerVersionPage!
+  vaultProvider(id: String!): vaultProvider
+  vaultProviders(where: vaultProviderFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): vaultProviderPage!
+  vaultProviderStats(id: String!): vaultProviderStats
+  vaultProviderStatss(where: vaultProviderStatsFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): vaultProviderStatsPage!
+  vault(id: String!): vault
+  vaults(where: vaultFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): vaultPage!
+  stats(id: String!): stats
+  statss(where: statsFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): statsPage!
+  protocolState(id: String!): protocolState
+  protocolStates(where: protocolStateFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): protocolStatePage!
+  vaultActivity(id: String!): vaultActivity
+  vaultActivitys(where: vaultActivityFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): vaultActivityPage!
+  feeConfig(id: String!): feeConfig
+  feeConfigs(where: feeConfigFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): feeConfigPage!
+  vaultFeeEscrow(vaultId: String!): vaultFeeEscrow
+  vaultFeeEscrows(where: vaultFeeEscrowFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): vaultFeeEscrowPage!
+  aaveConfig(id: Int!): aaveConfig
+  aaveConfigs(where: aaveConfigFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): aaveConfigPage!
+  aaveReserve(id: BigInt!): aaveReserve
+  aaveReserves(where: aaveReserveFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): aaveReservePage!
+  aavePosition(depositorAddress: String!): aavePosition
+  aavePositions(where: aavePositionFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): aavePositionPage!
+  aavePositionCollateral(depositorAddress: String!, vaultId: String!): aavePositionCollateral
+  aavePositionCollaterals(where: aavePositionCollateralFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): aavePositionCollateralPage!
+  aaveVaultStatus(vaultId: String!): aaveVaultStatus
+  aaveVaultStatuss(where: aaveVaultStatusFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): aaveVaultStatusPage!
+  aaveUserProxy(user: String!): aaveUserProxy
+  aaveUserProxys(where: aaveUserProxyFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int, offset: Int): aaveUserProxyPage!
+  _meta: Meta
+}
+
+type stats {
+  id: String!
+  totalAvailableSats: BigInt!
+  availableVaultCount: Int!
+  updatedAt: BigInt!
+}
+
+input statsFilter {
+  AND: [statsFilter]
+  OR: [statsFilter]
+  id: String
+  id_not: String
+  id_in: [String]
+  id_not_in: [String]
+  id_contains: String
+  id_not_contains: String
+  id_starts_with: String
+  id_ends_with: String
+  id_not_starts_with: String
+  id_not_ends_with: String
+  totalAvailableSats: BigInt
+  totalAvailableSats_not: BigInt
+  totalAvailableSats_in: [BigInt]
+  totalAvailableSats_not_in: [BigInt]
+  totalAvailableSats_gt: BigInt
+  totalAvailableSats_lt: BigInt
+  totalAvailableSats_gte: BigInt
+  totalAvailableSats_lte: BigInt
+  availableVaultCount: Int
+  availableVaultCount_not: Int
+  availableVaultCount_in: [Int]
+  availableVaultCount_not_in: [Int]
+  availableVaultCount_gt: Int
+  availableVaultCount_lt: Int
+  availableVaultCount_gte: Int
+  availableVaultCount_lte: Int
+  updatedAt: BigInt
+  updatedAt_not: BigInt
+  updatedAt_in: [BigInt]
+  updatedAt_not_in: [BigInt]
+  updatedAt_gt: BigInt
+  updatedAt_lt: BigInt
+  updatedAt_gte: BigInt
+  updatedAt_lte: BigInt
+}
+
+type statsPage {
+  items: [stats!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+""" The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text. """
+scalar String
+
+type token {
+  address: String!
+  symbol: String!
+  name: String!
+  decimals: Int!
+}
+
+input tokenFilter {
+  AND: [tokenFilter]
+  OR: [tokenFilter]
+  address: String
+  address_not: String
+  address_in: [String]
+  address_not_in: [String]
+  address_contains: String
+  address_not_contains: String
+  address_starts_with: String
+  address_ends_with: String
+  address_not_starts_with: String
+  address_not_ends_with: String
+  symbol: String
+  symbol_not: String
+  symbol_in: [String]
+  symbol_not_in: [String]
+  symbol_contains: String
+  symbol_not_contains: String
+  symbol_starts_with: String
+  symbol_ends_with: String
+  symbol_not_starts_with: String
+  symbol_not_ends_with: String
+  name: String
+  name_not: String
+  name_in: [String]
+  name_not_in: [String]
+  name_contains: String
+  name_not_contains: String
+  name_starts_with: String
+  name_ends_with: String
+  name_not_starts_with: String
+  name_not_ends_with: String
+  decimals: Int
+  decimals_not: Int
+  decimals_in: [Int]
+  decimals_not_in: [Int]
+  decimals_gt: Int
+  decimals_lt: Int
+  decimals_gte: Int
+  decimals_lte: Int
+}
+
+type tokenPage {
+  items: [token!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type universalChallenger {
+  id: String!
+  btcPubKey: String!
+  firstSeenAt: BigInt!
+  blockNumber: BigInt!
+}
+
+input universalChallengerFilter {
+  AND: [universalChallengerFilter]
+  OR: [universalChallengerFilter]
+  id: String
+  id_not: String
+  id_in: [String]
+  id_not_in: [String]
+  id_contains: String
+  id_not_contains: String
+  id_starts_with: String
+  id_ends_with: String
+  id_not_starts_with: String
+  id_not_ends_with: String
+  btcPubKey: String
+  btcPubKey_not: String
+  btcPubKey_in: [String]
+  btcPubKey_not_in: [String]
+  btcPubKey_contains: String
+  btcPubKey_not_contains: String
+  btcPubKey_starts_with: String
+  btcPubKey_ends_with: String
+  btcPubKey_not_starts_with: String
+  btcPubKey_not_ends_with: String
+  firstSeenAt: BigInt
+  firstSeenAt_not: BigInt
+  firstSeenAt_in: [BigInt]
+  firstSeenAt_not_in: [BigInt]
+  firstSeenAt_gt: BigInt
+  firstSeenAt_lt: BigInt
+  firstSeenAt_gte: BigInt
+  firstSeenAt_lte: BigInt
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_in: [BigInt]
+  blockNumber_not_in: [BigInt]
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+}
+
+type universalChallengerPage {
+  items: [universalChallenger!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type universalChallengerVersion {
+  id: String!
+  challengerId: String!
+  version: Int!
+  blockNumber: BigInt!
+  challengerInfo: universalChallenger
+}
+
+input universalChallengerVersionFilter {
+  AND: [universalChallengerVersionFilter]
+  OR: [universalChallengerVersionFilter]
+  id: String
+  id_not: String
+  id_in: [String]
+  id_not_in: [String]
+  id_contains: String
+  id_not_contains: String
+  id_starts_with: String
+  id_ends_with: String
+  id_not_starts_with: String
+  id_not_ends_with: String
+  challengerId: String
+  challengerId_not: String
+  challengerId_in: [String]
+  challengerId_not_in: [String]
+  challengerId_contains: String
+  challengerId_not_contains: String
+  challengerId_starts_with: String
+  challengerId_ends_with: String
+  challengerId_not_starts_with: String
+  challengerId_not_ends_with: String
+  version: Int
+  version_not: Int
+  version_in: [Int]
+  version_not_in: [Int]
+  version_gt: Int
+  version_lt: Int
+  version_gte: Int
+  version_lte: Int
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_in: [BigInt]
+  blockNumber_not_in: [BigInt]
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+}
+
+type universalChallengerVersionPage {
+  items: [universalChallengerVersion!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type vault {
+  id: String!
+  peginTxHash: String!
+  depositor: String!
+  depositorBtcPubKey: String!
+  vaultProvider: String!
+  vaultProviderCommissionBps: Int!
+  amount: BigInt!
+  applicationEntryPoint: String!
+  status: vaultStatus
+  inUse: Boolean!
+  ackCount: Int!
+  depositorSignedPeginTx: String!
+  unsignedPrePeginTx: String!
+  appVaultKeepersVersion: Int!
+  universalChallengersVersion: Int!
+  offchainParamsVersion: Int!
+  proverCircuitVersion: Int!
+  vaultCoreVersion: Int!
+  referralCode: Int!
+  depositorPayoutBtcAddress: String!
+  btcPopSignature: String
+  depositorWotsPkHash: String
+  peginSigsPostedAt: BigInt
+  prePeginTxHash: String
+  htlcVout: Int!
+  hashlock: String!
+  secret: String
+  currentOwner: String
+  pendingAt: BigInt!
+  verifiedAt: BigInt
+  activatedAt: BigInt
+  expiredAt: BigInt
+  expirationReason: String
+  claimExpiredUntil: BigInt
+  expiredClaimedAt: BigInt
+  blockNumber: BigInt!
+  transactionHash: String!
+  application: application
+}
+
+type vaultActivity {
+  id: String!
+  vaultId: String
+  depositor: String!
+  type: vaultActivityType!
+  amount: BigInt!
+  debtReserveId: BigInt
+  timestamp: BigInt!
+  blockNumber: BigInt!
+  transactionHash: String!
+}
+
+input vaultActivityFilter {
+  AND: [vaultActivityFilter]
+  OR: [vaultActivityFilter]
+  id: String
+  id_not: String
+  id_in: [String]
+  id_not_in: [String]
+  id_contains: String
+  id_not_contains: String
+  id_starts_with: String
+  id_ends_with: String
+  id_not_starts_with: String
+  id_not_ends_with: String
+  vaultId: String
+  vaultId_not: String
+  vaultId_in: [String]
+  vaultId_not_in: [String]
+  vaultId_contains: String
+  vaultId_not_contains: String
+  vaultId_starts_with: String
+  vaultId_ends_with: String
+  vaultId_not_starts_with: String
+  vaultId_not_ends_with: String
+  depositor: String
+  depositor_not: String
+  depositor_in: [String]
+  depositor_not_in: [String]
+  depositor_contains: String
+  depositor_not_contains: String
+  depositor_starts_with: String
+  depositor_ends_with: String
+  depositor_not_starts_with: String
+  depositor_not_ends_with: String
+  type: vaultActivityType
+  type_not: vaultActivityType
+  type_in: [vaultActivityType]
+  type_not_in: [vaultActivityType]
+  amount: BigInt
+  amount_not: BigInt
+  amount_in: [BigInt]
+  amount_not_in: [BigInt]
+  amount_gt: BigInt
+  amount_lt: BigInt
+  amount_gte: BigInt
+  amount_lte: BigInt
+  debtReserveId: BigInt
+  debtReserveId_not: BigInt
+  debtReserveId_in: [BigInt]
+  debtReserveId_not_in: [BigInt]
+  debtReserveId_gt: BigInt
+  debtReserveId_lt: BigInt
+  debtReserveId_gte: BigInt
+  debtReserveId_lte: BigInt
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_in: [BigInt]
+  timestamp_not_in: [BigInt]
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_in: [BigInt]
+  blockNumber_not_in: [BigInt]
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  transactionHash: String
+  transactionHash_not: String
+  transactionHash_in: [String]
+  transactionHash_not_in: [String]
+  transactionHash_contains: String
+  transactionHash_not_contains: String
+  transactionHash_starts_with: String
+  transactionHash_ends_with: String
+  transactionHash_not_starts_with: String
+  transactionHash_not_ends_with: String
+}
+
+type vaultActivityPage {
+  items: [vaultActivity!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+enum vaultActivityType {
+  deposit
+  withdrawal
+  add_collateral
+  remove_collateral
+  liquidation
+  borrow
+  repay
+  redeem
+  claim_expired
+}
+
+type vaultFeeEscrow {
+  vaultId: String!
+  totalAmount: BigInt!
+  vaultProvider: String!
+  numUniversalChallengers: Int!
+  numAppVaultKeepers: Int!
+  status: feeEscrowStatus!
+  escrowedAt: BigInt!
+  distributedAt: BigInt
+  refundedAt: BigInt
+  forfeitedAt: BigInt
+  blockNumber: BigInt!
+  transactionHash: String!
+  vault: vault
+}
+
+input vaultFeeEscrowFilter {
+  AND: [vaultFeeEscrowFilter]
+  OR: [vaultFeeEscrowFilter]
+  vaultId: String
+  vaultId_not: String
+  vaultId_in: [String]
+  vaultId_not_in: [String]
+  vaultId_contains: String
+  vaultId_not_contains: String
+  vaultId_starts_with: String
+  vaultId_ends_with: String
+  vaultId_not_starts_with: String
+  vaultId_not_ends_with: String
+  totalAmount: BigInt
+  totalAmount_not: BigInt
+  totalAmount_in: [BigInt]
+  totalAmount_not_in: [BigInt]
+  totalAmount_gt: BigInt
+  totalAmount_lt: BigInt
+  totalAmount_gte: BigInt
+  totalAmount_lte: BigInt
+  vaultProvider: String
+  vaultProvider_not: String
+  vaultProvider_in: [String]
+  vaultProvider_not_in: [String]
+  vaultProvider_contains: String
+  vaultProvider_not_contains: String
+  vaultProvider_starts_with: String
+  vaultProvider_ends_with: String
+  vaultProvider_not_starts_with: String
+  vaultProvider_not_ends_with: String
+  numUniversalChallengers: Int
+  numUniversalChallengers_not: Int
+  numUniversalChallengers_in: [Int]
+  numUniversalChallengers_not_in: [Int]
+  numUniversalChallengers_gt: Int
+  numUniversalChallengers_lt: Int
+  numUniversalChallengers_gte: Int
+  numUniversalChallengers_lte: Int
+  numAppVaultKeepers: Int
+  numAppVaultKeepers_not: Int
+  numAppVaultKeepers_in: [Int]
+  numAppVaultKeepers_not_in: [Int]
+  numAppVaultKeepers_gt: Int
+  numAppVaultKeepers_lt: Int
+  numAppVaultKeepers_gte: Int
+  numAppVaultKeepers_lte: Int
+  status: feeEscrowStatus
+  status_not: feeEscrowStatus
+  status_in: [feeEscrowStatus]
+  status_not_in: [feeEscrowStatus]
+  escrowedAt: BigInt
+  escrowedAt_not: BigInt
+  escrowedAt_in: [BigInt]
+  escrowedAt_not_in: [BigInt]
+  escrowedAt_gt: BigInt
+  escrowedAt_lt: BigInt
+  escrowedAt_gte: BigInt
+  escrowedAt_lte: BigInt
+  distributedAt: BigInt
+  distributedAt_not: BigInt
+  distributedAt_in: [BigInt]
+  distributedAt_not_in: [BigInt]
+  distributedAt_gt: BigInt
+  distributedAt_lt: BigInt
+  distributedAt_gte: BigInt
+  distributedAt_lte: BigInt
+  refundedAt: BigInt
+  refundedAt_not: BigInt
+  refundedAt_in: [BigInt]
+  refundedAt_not_in: [BigInt]
+  refundedAt_gt: BigInt
+  refundedAt_lt: BigInt
+  refundedAt_gte: BigInt
+  refundedAt_lte: BigInt
+  forfeitedAt: BigInt
+  forfeitedAt_not: BigInt
+  forfeitedAt_in: [BigInt]
+  forfeitedAt_not_in: [BigInt]
+  forfeitedAt_gt: BigInt
+  forfeitedAt_lt: BigInt
+  forfeitedAt_gte: BigInt
+  forfeitedAt_lte: BigInt
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_in: [BigInt]
+  blockNumber_not_in: [BigInt]
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  transactionHash: String
+  transactionHash_not: String
+  transactionHash_in: [String]
+  transactionHash_not_in: [String]
+  transactionHash_contains: String
+  transactionHash_not_contains: String
+  transactionHash_starts_with: String
+  transactionHash_ends_with: String
+  transactionHash_not_starts_with: String
+  transactionHash_not_ends_with: String
+}
+
+type vaultFeeEscrowPage {
+  items: [vaultFeeEscrow!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+input vaultFilter {
+  AND: [vaultFilter]
+  OR: [vaultFilter]
+  id: String
+  id_not: String
+  id_in: [String]
+  id_not_in: [String]
+  id_contains: String
+  id_not_contains: String
+  id_starts_with: String
+  id_ends_with: String
+  id_not_starts_with: String
+  id_not_ends_with: String
+  peginTxHash: String
+  peginTxHash_not: String
+  peginTxHash_in: [String]
+  peginTxHash_not_in: [String]
+  peginTxHash_contains: String
+  peginTxHash_not_contains: String
+  peginTxHash_starts_with: String
+  peginTxHash_ends_with: String
+  peginTxHash_not_starts_with: String
+  peginTxHash_not_ends_with: String
+  depositor: String
+  depositor_not: String
+  depositor_in: [String]
+  depositor_not_in: [String]
+  depositor_contains: String
+  depositor_not_contains: String
+  depositor_starts_with: String
+  depositor_ends_with: String
+  depositor_not_starts_with: String
+  depositor_not_ends_with: String
+  depositorBtcPubKey: String
+  depositorBtcPubKey_not: String
+  depositorBtcPubKey_in: [String]
+  depositorBtcPubKey_not_in: [String]
+  depositorBtcPubKey_contains: String
+  depositorBtcPubKey_not_contains: String
+  depositorBtcPubKey_starts_with: String
+  depositorBtcPubKey_ends_with: String
+  depositorBtcPubKey_not_starts_with: String
+  depositorBtcPubKey_not_ends_with: String
+  vaultProvider: String
+  vaultProvider_not: String
+  vaultProvider_in: [String]
+  vaultProvider_not_in: [String]
+  vaultProvider_contains: String
+  vaultProvider_not_contains: String
+  vaultProvider_starts_with: String
+  vaultProvider_ends_with: String
+  vaultProvider_not_starts_with: String
+  vaultProvider_not_ends_with: String
+  vaultProviderCommissionBps: Int
+  vaultProviderCommissionBps_not: Int
+  vaultProviderCommissionBps_in: [Int]
+  vaultProviderCommissionBps_not_in: [Int]
+  vaultProviderCommissionBps_gt: Int
+  vaultProviderCommissionBps_lt: Int
+  vaultProviderCommissionBps_gte: Int
+  vaultProviderCommissionBps_lte: Int
+  amount: BigInt
+  amount_not: BigInt
+  amount_in: [BigInt]
+  amount_not_in: [BigInt]
+  amount_gt: BigInt
+  amount_lt: BigInt
+  amount_gte: BigInt
+  amount_lte: BigInt
+  applicationEntryPoint: String
+  applicationEntryPoint_not: String
+  applicationEntryPoint_in: [String]
+  applicationEntryPoint_not_in: [String]
+  applicationEntryPoint_contains: String
+  applicationEntryPoint_not_contains: String
+  applicationEntryPoint_starts_with: String
+  applicationEntryPoint_ends_with: String
+  applicationEntryPoint_not_starts_with: String
+  applicationEntryPoint_not_ends_with: String
+  status: vaultStatus
+  status_not: vaultStatus
+  status_in: [vaultStatus]
+  status_not_in: [vaultStatus]
+  inUse: Boolean
+  inUse_not: Boolean
+  inUse_in: [Boolean]
+  inUse_not_in: [Boolean]
+  ackCount: Int
+  ackCount_not: Int
+  ackCount_in: [Int]
+  ackCount_not_in: [Int]
+  ackCount_gt: Int
+  ackCount_lt: Int
+  ackCount_gte: Int
+  ackCount_lte: Int
+  depositorSignedPeginTx: String
+  depositorSignedPeginTx_not: String
+  depositorSignedPeginTx_in: [String]
+  depositorSignedPeginTx_not_in: [String]
+  depositorSignedPeginTx_contains: String
+  depositorSignedPeginTx_not_contains: String
+  depositorSignedPeginTx_starts_with: String
+  depositorSignedPeginTx_ends_with: String
+  depositorSignedPeginTx_not_starts_with: String
+  depositorSignedPeginTx_not_ends_with: String
+  unsignedPrePeginTx: String
+  unsignedPrePeginTx_not: String
+  unsignedPrePeginTx_in: [String]
+  unsignedPrePeginTx_not_in: [String]
+  unsignedPrePeginTx_contains: String
+  unsignedPrePeginTx_not_contains: String
+  unsignedPrePeginTx_starts_with: String
+  unsignedPrePeginTx_ends_with: String
+  unsignedPrePeginTx_not_starts_with: String
+  unsignedPrePeginTx_not_ends_with: String
+  appVaultKeepersVersion: Int
+  appVaultKeepersVersion_not: Int
+  appVaultKeepersVersion_in: [Int]
+  appVaultKeepersVersion_not_in: [Int]
+  appVaultKeepersVersion_gt: Int
+  appVaultKeepersVersion_lt: Int
+  appVaultKeepersVersion_gte: Int
+  appVaultKeepersVersion_lte: Int
+  universalChallengersVersion: Int
+  universalChallengersVersion_not: Int
+  universalChallengersVersion_in: [Int]
+  universalChallengersVersion_not_in: [Int]
+  universalChallengersVersion_gt: Int
+  universalChallengersVersion_lt: Int
+  universalChallengersVersion_gte: Int
+  universalChallengersVersion_lte: Int
+  offchainParamsVersion: Int
+  offchainParamsVersion_not: Int
+  offchainParamsVersion_in: [Int]
+  offchainParamsVersion_not_in: [Int]
+  offchainParamsVersion_gt: Int
+  offchainParamsVersion_lt: Int
+  offchainParamsVersion_gte: Int
+  offchainParamsVersion_lte: Int
+  proverCircuitVersion: Int
+  proverCircuitVersion_not: Int
+  proverCircuitVersion_in: [Int]
+  proverCircuitVersion_not_in: [Int]
+  proverCircuitVersion_gt: Int
+  proverCircuitVersion_lt: Int
+  proverCircuitVersion_gte: Int
+  proverCircuitVersion_lte: Int
+  vaultCoreVersion: Int
+  vaultCoreVersion_not: Int
+  vaultCoreVersion_in: [Int]
+  vaultCoreVersion_not_in: [Int]
+  vaultCoreVersion_gt: Int
+  vaultCoreVersion_lt: Int
+  vaultCoreVersion_gte: Int
+  vaultCoreVersion_lte: Int
+  referralCode: Int
+  referralCode_not: Int
+  referralCode_in: [Int]
+  referralCode_not_in: [Int]
+  referralCode_gt: Int
+  referralCode_lt: Int
+  referralCode_gte: Int
+  referralCode_lte: Int
+  depositorPayoutBtcAddress: String
+  depositorPayoutBtcAddress_not: String
+  depositorPayoutBtcAddress_in: [String]
+  depositorPayoutBtcAddress_not_in: [String]
+  depositorPayoutBtcAddress_contains: String
+  depositorPayoutBtcAddress_not_contains: String
+  depositorPayoutBtcAddress_starts_with: String
+  depositorPayoutBtcAddress_ends_with: String
+  depositorPayoutBtcAddress_not_starts_with: String
+  depositorPayoutBtcAddress_not_ends_with: String
+  btcPopSignature: String
+  btcPopSignature_not: String
+  btcPopSignature_in: [String]
+  btcPopSignature_not_in: [String]
+  btcPopSignature_contains: String
+  btcPopSignature_not_contains: String
+  btcPopSignature_starts_with: String
+  btcPopSignature_ends_with: String
+  btcPopSignature_not_starts_with: String
+  btcPopSignature_not_ends_with: String
+  depositorWotsPkHash: String
+  depositorWotsPkHash_not: String
+  depositorWotsPkHash_in: [String]
+  depositorWotsPkHash_not_in: [String]
+  depositorWotsPkHash_contains: String
+  depositorWotsPkHash_not_contains: String
+  depositorWotsPkHash_starts_with: String
+  depositorWotsPkHash_ends_with: String
+  depositorWotsPkHash_not_starts_with: String
+  depositorWotsPkHash_not_ends_with: String
+  peginSigsPostedAt: BigInt
+  peginSigsPostedAt_not: BigInt
+  peginSigsPostedAt_in: [BigInt]
+  peginSigsPostedAt_not_in: [BigInt]
+  peginSigsPostedAt_gt: BigInt
+  peginSigsPostedAt_lt: BigInt
+  peginSigsPostedAt_gte: BigInt
+  peginSigsPostedAt_lte: BigInt
+  prePeginTxHash: String
+  prePeginTxHash_not: String
+  prePeginTxHash_in: [String]
+  prePeginTxHash_not_in: [String]
+  prePeginTxHash_contains: String
+  prePeginTxHash_not_contains: String
+  prePeginTxHash_starts_with: String
+  prePeginTxHash_ends_with: String
+  prePeginTxHash_not_starts_with: String
+  prePeginTxHash_not_ends_with: String
+  htlcVout: Int
+  htlcVout_not: Int
+  htlcVout_in: [Int]
+  htlcVout_not_in: [Int]
+  htlcVout_gt: Int
+  htlcVout_lt: Int
+  htlcVout_gte: Int
+  htlcVout_lte: Int
+  hashlock: String
+  hashlock_not: String
+  hashlock_in: [String]
+  hashlock_not_in: [String]
+  hashlock_contains: String
+  hashlock_not_contains: String
+  hashlock_starts_with: String
+  hashlock_ends_with: String
+  hashlock_not_starts_with: String
+  hashlock_not_ends_with: String
+  secret: String
+  secret_not: String
+  secret_in: [String]
+  secret_not_in: [String]
+  secret_contains: String
+  secret_not_contains: String
+  secret_starts_with: String
+  secret_ends_with: String
+  secret_not_starts_with: String
+  secret_not_ends_with: String
+  currentOwner: String
+  currentOwner_not: String
+  currentOwner_in: [String]
+  currentOwner_not_in: [String]
+  currentOwner_contains: String
+  currentOwner_not_contains: String
+  currentOwner_starts_with: String
+  currentOwner_ends_with: String
+  currentOwner_not_starts_with: String
+  currentOwner_not_ends_with: String
+  pendingAt: BigInt
+  pendingAt_not: BigInt
+  pendingAt_in: [BigInt]
+  pendingAt_not_in: [BigInt]
+  pendingAt_gt: BigInt
+  pendingAt_lt: BigInt
+  pendingAt_gte: BigInt
+  pendingAt_lte: BigInt
+  verifiedAt: BigInt
+  verifiedAt_not: BigInt
+  verifiedAt_in: [BigInt]
+  verifiedAt_not_in: [BigInt]
+  verifiedAt_gt: BigInt
+  verifiedAt_lt: BigInt
+  verifiedAt_gte: BigInt
+  verifiedAt_lte: BigInt
+  activatedAt: BigInt
+  activatedAt_not: BigInt
+  activatedAt_in: [BigInt]
+  activatedAt_not_in: [BigInt]
+  activatedAt_gt: BigInt
+  activatedAt_lt: BigInt
+  activatedAt_gte: BigInt
+  activatedAt_lte: BigInt
+  expiredAt: BigInt
+  expiredAt_not: BigInt
+  expiredAt_in: [BigInt]
+  expiredAt_not_in: [BigInt]
+  expiredAt_gt: BigInt
+  expiredAt_lt: BigInt
+  expiredAt_gte: BigInt
+  expiredAt_lte: BigInt
+  expirationReason: String
+  expirationReason_not: String
+  expirationReason_in: [String]
+  expirationReason_not_in: [String]
+  expirationReason_contains: String
+  expirationReason_not_contains: String
+  expirationReason_starts_with: String
+  expirationReason_ends_with: String
+  expirationReason_not_starts_with: String
+  expirationReason_not_ends_with: String
+  claimExpiredUntil: BigInt
+  claimExpiredUntil_not: BigInt
+  claimExpiredUntil_in: [BigInt]
+  claimExpiredUntil_not_in: [BigInt]
+  claimExpiredUntil_gt: BigInt
+  claimExpiredUntil_lt: BigInt
+  claimExpiredUntil_gte: BigInt
+  claimExpiredUntil_lte: BigInt
+  expiredClaimedAt: BigInt
+  expiredClaimedAt_not: BigInt
+  expiredClaimedAt_in: [BigInt]
+  expiredClaimedAt_not_in: [BigInt]
+  expiredClaimedAt_gt: BigInt
+  expiredClaimedAt_lt: BigInt
+  expiredClaimedAt_gte: BigInt
+  expiredClaimedAt_lte: BigInt
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_in: [BigInt]
+  blockNumber_not_in: [BigInt]
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  transactionHash: String
+  transactionHash_not: String
+  transactionHash_in: [String]
+  transactionHash_not_in: [String]
+  transactionHash_contains: String
+  transactionHash_not_contains: String
+  transactionHash_starts_with: String
+  transactionHash_ends_with: String
+  transactionHash_not_starts_with: String
+  transactionHash_not_ends_with: String
+}
+
+type vaultKeeper {
+  id: String!
+  btcPubKey: String!
+  firstSeenAt: BigInt!
+  blockNumber: BigInt!
+}
+
+type vaultKeeperApplication {
+  id: String!
+  vaultKeeper: String!
+  applicationEntryPoint: String!
+  version: Int!
+  registeredAt: BigInt!
+  blockNumber: BigInt!
+  vaultKeeperInfo: vaultKeeper
+}
+
+input vaultKeeperApplicationFilter {
+  AND: [vaultKeeperApplicationFilter]
+  OR: [vaultKeeperApplicationFilter]
+  id: String
+  id_not: String
+  id_in: [String]
+  id_not_in: [String]
+  id_contains: String
+  id_not_contains: String
+  id_starts_with: String
+  id_ends_with: String
+  id_not_starts_with: String
+  id_not_ends_with: String
+  vaultKeeper: String
+  vaultKeeper_not: String
+  vaultKeeper_in: [String]
+  vaultKeeper_not_in: [String]
+  vaultKeeper_contains: String
+  vaultKeeper_not_contains: String
+  vaultKeeper_starts_with: String
+  vaultKeeper_ends_with: String
+  vaultKeeper_not_starts_with: String
+  vaultKeeper_not_ends_with: String
+  applicationEntryPoint: String
+  applicationEntryPoint_not: String
+  applicationEntryPoint_in: [String]
+  applicationEntryPoint_not_in: [String]
+  applicationEntryPoint_contains: String
+  applicationEntryPoint_not_contains: String
+  applicationEntryPoint_starts_with: String
+  applicationEntryPoint_ends_with: String
+  applicationEntryPoint_not_starts_with: String
+  applicationEntryPoint_not_ends_with: String
+  version: Int
+  version_not: Int
+  version_in: [Int]
+  version_not_in: [Int]
+  version_gt: Int
+  version_lt: Int
+  version_gte: Int
+  version_lte: Int
+  registeredAt: BigInt
+  registeredAt_not: BigInt
+  registeredAt_in: [BigInt]
+  registeredAt_not_in: [BigInt]
+  registeredAt_gt: BigInt
+  registeredAt_lt: BigInt
+  registeredAt_gte: BigInt
+  registeredAt_lte: BigInt
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_in: [BigInt]
+  blockNumber_not_in: [BigInt]
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+}
+
+type vaultKeeperApplicationPage {
+  items: [vaultKeeperApplication!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+input vaultKeeperFilter {
+  AND: [vaultKeeperFilter]
+  OR: [vaultKeeperFilter]
+  id: String
+  id_not: String
+  id_in: [String]
+  id_not_in: [String]
+  id_contains: String
+  id_not_contains: String
+  id_starts_with: String
+  id_ends_with: String
+  id_not_starts_with: String
+  id_not_ends_with: String
+  btcPubKey: String
+  btcPubKey_not: String
+  btcPubKey_in: [String]
+  btcPubKey_not_in: [String]
+  btcPubKey_contains: String
+  btcPubKey_not_contains: String
+  btcPubKey_starts_with: String
+  btcPubKey_ends_with: String
+  btcPubKey_not_starts_with: String
+  btcPubKey_not_ends_with: String
+  firstSeenAt: BigInt
+  firstSeenAt_not: BigInt
+  firstSeenAt_in: [BigInt]
+  firstSeenAt_not_in: [BigInt]
+  firstSeenAt_gt: BigInt
+  firstSeenAt_lt: BigInt
+  firstSeenAt_gte: BigInt
+  firstSeenAt_lte: BigInt
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_in: [BigInt]
+  blockNumber_not_in: [BigInt]
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+}
+
+type vaultKeeperPage {
+  items: [vaultKeeper!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type vaultPage {
+  items: [vault!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type vaultProvider {
+  id: String!
+  btcPubKey: String!
+  applicationEntryPoint: String!
+  commissionBps: Int!
+  name: String
+  rpcUrl: String
+  grpcUrl: String
+  daemonGrpcUrl: String
+  metadataStatus: String
+  metadataRejectionReason: String
+  registeredAt: BigInt!
+  blockNumber: BigInt!
+  transactionHash: String!
+}
+
+input vaultProviderFilter {
+  AND: [vaultProviderFilter]
+  OR: [vaultProviderFilter]
+  id: String
+  id_not: String
+  id_in: [String]
+  id_not_in: [String]
+  id_contains: String
+  id_not_contains: String
+  id_starts_with: String
+  id_ends_with: String
+  id_not_starts_with: String
+  id_not_ends_with: String
+  btcPubKey: String
+  btcPubKey_not: String
+  btcPubKey_in: [String]
+  btcPubKey_not_in: [String]
+  btcPubKey_contains: String
+  btcPubKey_not_contains: String
+  btcPubKey_starts_with: String
+  btcPubKey_ends_with: String
+  btcPubKey_not_starts_with: String
+  btcPubKey_not_ends_with: String
+  applicationEntryPoint: String
+  applicationEntryPoint_not: String
+  applicationEntryPoint_in: [String]
+  applicationEntryPoint_not_in: [String]
+  applicationEntryPoint_contains: String
+  applicationEntryPoint_not_contains: String
+  applicationEntryPoint_starts_with: String
+  applicationEntryPoint_ends_with: String
+  applicationEntryPoint_not_starts_with: String
+  applicationEntryPoint_not_ends_with: String
+  commissionBps: Int
+  commissionBps_not: Int
+  commissionBps_in: [Int]
+  commissionBps_not_in: [Int]
+  commissionBps_gt: Int
+  commissionBps_lt: Int
+  commissionBps_gte: Int
+  commissionBps_lte: Int
+  name: String
+  name_not: String
+  name_in: [String]
+  name_not_in: [String]
+  name_contains: String
+  name_not_contains: String
+  name_starts_with: String
+  name_ends_with: String
+  name_not_starts_with: String
+  name_not_ends_with: String
+  rpcUrl: String
+  rpcUrl_not: String
+  rpcUrl_in: [String]
+  rpcUrl_not_in: [String]
+  rpcUrl_contains: String
+  rpcUrl_not_contains: String
+  rpcUrl_starts_with: String
+  rpcUrl_ends_with: String
+  rpcUrl_not_starts_with: String
+  rpcUrl_not_ends_with: String
+  grpcUrl: String
+  grpcUrl_not: String
+  grpcUrl_in: [String]
+  grpcUrl_not_in: [String]
+  grpcUrl_contains: String
+  grpcUrl_not_contains: String
+  grpcUrl_starts_with: String
+  grpcUrl_ends_with: String
+  grpcUrl_not_starts_with: String
+  grpcUrl_not_ends_with: String
+  daemonGrpcUrl: String
+  daemonGrpcUrl_not: String
+  daemonGrpcUrl_in: [String]
+  daemonGrpcUrl_not_in: [String]
+  daemonGrpcUrl_contains: String
+  daemonGrpcUrl_not_contains: String
+  daemonGrpcUrl_starts_with: String
+  daemonGrpcUrl_ends_with: String
+  daemonGrpcUrl_not_starts_with: String
+  daemonGrpcUrl_not_ends_with: String
+  metadataStatus: String
+  metadataStatus_not: String
+  metadataStatus_in: [String]
+  metadataStatus_not_in: [String]
+  metadataStatus_contains: String
+  metadataStatus_not_contains: String
+  metadataStatus_starts_with: String
+  metadataStatus_ends_with: String
+  metadataStatus_not_starts_with: String
+  metadataStatus_not_ends_with: String
+  metadataRejectionReason: String
+  metadataRejectionReason_not: String
+  metadataRejectionReason_in: [String]
+  metadataRejectionReason_not_in: [String]
+  metadataRejectionReason_contains: String
+  metadataRejectionReason_not_contains: String
+  metadataRejectionReason_starts_with: String
+  metadataRejectionReason_ends_with: String
+  metadataRejectionReason_not_starts_with: String
+  metadataRejectionReason_not_ends_with: String
+  registeredAt: BigInt
+  registeredAt_not: BigInt
+  registeredAt_in: [BigInt]
+  registeredAt_not_in: [BigInt]
+  registeredAt_gt: BigInt
+  registeredAt_lt: BigInt
+  registeredAt_gte: BigInt
+  registeredAt_lte: BigInt
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_in: [BigInt]
+  blockNumber_not_in: [BigInt]
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  transactionHash: String
+  transactionHash_not: String
+  transactionHash_in: [String]
+  transactionHash_not_in: [String]
+  transactionHash_contains: String
+  transactionHash_not_contains: String
+  transactionHash_starts_with: String
+  transactionHash_ends_with: String
+  transactionHash_not_starts_with: String
+  transactionHash_not_ends_with: String
+}
+
+type vaultProviderPage {
+  items: [vaultProvider!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type vaultProviderStats {
+  id: String!
+  activeVaultCount: Int!
+  totalActiveSats: BigInt!
+  updatedAt: BigInt!
+  provider: vaultProvider
+}
+
+input vaultProviderStatsFilter {
+  AND: [vaultProviderStatsFilter]
+  OR: [vaultProviderStatsFilter]
+  id: String
+  id_not: String
+  id_in: [String]
+  id_not_in: [String]
+  id_contains: String
+  id_not_contains: String
+  id_starts_with: String
+  id_ends_with: String
+  id_not_starts_with: String
+  id_not_ends_with: String
+  activeVaultCount: Int
+  activeVaultCount_not: Int
+  activeVaultCount_in: [Int]
+  activeVaultCount_not_in: [Int]
+  activeVaultCount_gt: Int
+  activeVaultCount_lt: Int
+  activeVaultCount_gte: Int
+  activeVaultCount_lte: Int
+  totalActiveSats: BigInt
+  totalActiveSats_not: BigInt
+  totalActiveSats_in: [BigInt]
+  totalActiveSats_not_in: [BigInt]
+  totalActiveSats_gt: BigInt
+  totalActiveSats_lt: BigInt
+  totalActiveSats_gte: BigInt
+  totalActiveSats_lte: BigInt
+  updatedAt: BigInt
+  updatedAt_not: BigInt
+  updatedAt_in: [BigInt]
+  updatedAt_not_in: [BigInt]
+  updatedAt_gt: BigInt
+  updatedAt_lt: BigInt
+  updatedAt_gte: BigInt
+  updatedAt_lte: BigInt
+}
+
+type vaultProviderStatsPage {
+  items: [vaultProviderStats!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+enum vaultStatus {
+  pending
+  signatures_collected
+  verified
+  available
+  redeemed
+  liquidated
+  expired
+  invalid
+  depositor_withdrawn
+}
+
+type ViewPageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+}


### PR DESCRIPTION
## What this does

Documents the public **TBV vault indexer GraphQL API** ahead of the TBV launch, and reorganises API navigation so each product section owns its own APIs.

Draft: the skill and the schema-regeneration workflow land in separate PRs (`baby-skills`, `tbv-agent-skills`, `babylonlabs.github.io-actions`).

## New section — `docs/trustless-bitcoin-vault/apis/`

| Page | How it is produced |
| --- | --- |
| `vault-indexer-api.mdx` | Hand-written — endpoint, domains, explorer, freshness |
| `schema-reference.mdx` | **Generated** from the committed SDL — all 20 entities |
| `query-cookbook.mdx` | Worked queries for depositors, operators, builders |
| `limits-and-gotchas.mdx` | Depth cap, pagination, the 403 trap, known data gaps |

## Navigation change

- Removes the top-level **API** navbar dropdown.
- **Bitcoin Staking** sidebar gains an *APIs* category: Staking API, Babylon gRPC, CometBFT.
- **Trustless Bitcoin Vault** sidebar gains an *APIs* category.

**No redirects needed.** Only the navigation moved — the pages stay at `/api/*`, so no URL changes and no SEO risk. All three legacy URLs were verified to still resolve at their original paths.

## Tooling — `scripts/`

- **`fetch-vault-indexer-schema.mjs`** — introspects the deployed endpoint and writes the SDL. Supports `--check` for drift detection.
- **`gen-vault-indexer-docs.mjs`** — regenerates `schema-reference.mdx` from the SDL.
- **`verify-vault-indexer-queries.mjs`** — executes every GraphQL example in the docs against the live endpoint and fails if any does not run.

Neither the SDL nor the schema reference is written by hand or by an LLM. A wrong field in a schema reference is indistinguishable from a real one to a reader, so both stay mechanical.

## Three findings worth reviewer attention

**1. The hosted explorer cannot load its own schema.** The endpoint caps query depth at 10 (`babylon-vault-indexer`, `src/api/index.ts:22`). The standard `getIntrospectionQuery()` is depth 21, so GraphiQL's Docs pane shows `Error fetching schema` — as do Apollo Sandbox, Postman and `graphql-codegen`. Queries still execute. The limit is deliberate anti-abuse and is **not** being changed; the docs explain the workaround, and the committed SDL means most builders never need to introspect.

**2. A 403 means your User-Agent.** Cloudflare rejects default library user-agents with a bare 403 and no GraphQL error body — it reads as an outage or an auth wall. `Python-urllib/3.11` gets 403; a custom UA gets 200. Documented prominently.

**3. The deployed schema trails the indexer source repo.** `aaveReserveSnapshot` and the BTC-monitor entities exist at repo HEAD but are absent from production. All generated docs come from the **deployed** endpoint, never the repo.

## Verification

- Docs build clean, no broken links
- **20/20** GraphQL examples execute against testnet
- Navigation, sidebars and legacy `/api/*` URLs checked in a browser
- `feeConfig` is empty on testnet (0 rows, while 2,137 fee escrows exist) — documented rather than hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A91wnr5avZ8cQJMPMisvEk